### PR TITLE
added v0.2.0 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 0.2.0 April 3 2018 ####
+* Added support for sampling inside Petabridge.Tracing.Zipkin.
+* Extracted `IZipkinSpan` and `IZipkinSpanContext` interfaces in order to make it easier to work with mocks and fakes during testing.
+
 #### 0.1.1 March 26 2018 ####
 Fixed the following issues:
 

--- a/build.fsx
+++ b/build.fsx
@@ -50,8 +50,6 @@ Target "Clean" (fun _ ->
     CleanDir outputPerfTests
     CleanDir outputNuGet
     CleanDir "docs/_site"
-    CleanDirs !! "./**/bin"
-    CleanDirs !! "./**/obj"
 )
 
 Target "AssemblyInfo" (fun _ ->
@@ -68,17 +66,11 @@ Target "RestorePackages" (fun _ ->
 )
 
 Target "Build" (fun _ ->          
-    let runSingleProject project =
-        DotNetCli.Build
-            (fun p -> 
-                { p with
-                    Project = project
-                    Configuration = configuration 
-                    AdditionalArgs = ["--no-incremental"]}) // "Rebuild"  
-
-    let assemblies = !! "./src/**/*.csproj" 
-     
-    assemblies |> Seq.iter (runSingleProject)
+    DotNetCli.Build
+        (fun p -> 
+            { p with
+                Project = solutionFile
+                Configuration = configuration }) // "Rebuild"  
 )
 
 //--------------------------------------------------------------------------------

--- a/src/common.props
+++ b/src/common.props
@@ -2,11 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2018 Petabridge, LLC</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.1.1</VersionPrefix>
-    <PackageReleaseNotes>Fixed the following issues:
-[HTTP Reporting actor must cancel its task upon termination](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/13)
-[Add mechanism to terminate the Zipkin HTTP Reporter actor upon Dispose](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/12)
-[Allow HttpReportingActor to consume logging settings from outside ActorSystem](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/11)</PackageReleaseNotes>
+    <VersionPrefix>0.2.0</VersionPrefix>
+    <PackageReleaseNotes>Added support for sampling inside Petabridge.Tracing.Zipkin.
+Extracted `IZipkinSpan` and `IZipkinSpanContext` interfaces in order to make it easier to work with mocks and fakes during testing.</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://github.com/petabridge/Petabridge.Tracing.Zipkin


### PR DESCRIPTION
#### 0.2.0 April 3 2018 ####
* Added support for sampling inside Petabridge.Tracing.Zipkin.
* Extracted `IZipkinSpan` and `IZipkinSpanContext` interfaces in order to make it easier to work with mocks and fakes during testing.