### PR TITLE
v0.2.2 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 0.2.2 April 23 2018 ####
+* Upgraded to [Akka.NET v1.3.6](https://github.com/akkadotnet/akka.net/releases/tag/v1.3.6)
+* [Fixed: Initial tags created by IZipkinSpanBuilder aren't actually passed to span](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/25)
+
 #### 0.2.1 April 5 2018 ####
 * Fixed a bug that could occur during sampling where a `NoOpSpanContext` could accidentally be added as a parent under some circumstances. In these instances, we now filter these illegal span types out.
 

--- a/build.fsx
+++ b/build.fsx
@@ -170,7 +170,7 @@ Target "CreateNuget" (fun _ ->
                 { p with
                     Project = project
                     Configuration = configuration
-                    AdditionalArgs = ["--include-symbols"]
+                    AdditionalArgs = ["--include-symbols --no-build"]
                     VersionSuffix = overrideVersionSuffix project
                     OutputPath = outputNuGet })
 

--- a/src/Petabridge.Tracing.Zipkin.Tests/Bug25SpanTagsSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Bug25SpanTagsSpecs.cs
@@ -1,0 +1,52 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="Bug25SpanTagsSpecs.cs" company="Petabridge, LLC">
+//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using FluentAssertions;
+using Petabridge.Tracing.Zipkin.Tracers;
+using Xunit;
+
+namespace Petabridge.Tracing.Zipkin.Tests
+{
+    /// <summary>
+    ///     Specs aimed at proving the existence of and fix to
+    ///     https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/25
+    /// </summary>
+    public class Bug25SpanTagsSpecs
+    {
+        public Bug25SpanTagsSpecs()
+        {
+            Tracer = new MockZipkinTracer();
+        }
+
+        protected readonly MockZipkinTracer Tracer;
+
+        [Fact(DisplayName = "Should be able to apply and record tags to a SpanBuilder")]
+        public void ShouldAddTagsToSpanBeingBuilt()
+        {
+            var span = (Span) Tracer.BuildSpan("op1").WithTag("foo", "bar").WithTag("baz", 1).Start();
+            span.Finish();
+
+            // grab the span from the collector (since this is the state it'll be reported in)
+            Tracer.CollectedSpans.TryDequeue(out var finishedSpan).Should().BeTrue();
+            finishedSpan.Tags.Count.Should().Be(2);
+            finishedSpan.Tags["foo"].Should().Be("bar");
+            finishedSpan.Tags["baz"].Should().Be("1");
+        }
+
+        [Fact(DisplayName = "Should be able to apply and record tags to a started span")]
+        public void ShouldAddTagsToStartedSpan()
+        {
+            var span = (Span) Tracer.BuildSpan("op1").Start();
+            span.SetTag("foo", "bar").SetTag("baz", 1).Finish();
+
+            // grab the span from the collector (since this is the state it'll be reported in)
+            Tracer.CollectedSpans.TryDequeue(out var finishedSpan).Should().BeTrue();
+            finishedSpan.Tags.Count.Should().Be(2);
+            finishedSpan.Tags["foo"].Should().Be("bar");
+            finishedSpan.Tags["baz"].Should().Be("1");
+        }
+    }
+}

--- a/src/Petabridge.Tracing.Zipkin.Tests/Petabridge.Tracing.Zipkin.Tests.csproj
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Petabridge.Tracing.Zipkin.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.5" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.6" />
     <PackageReference Include="FluentAssertions" Version="5.2.0" />
     <PackageReference Include="FsCheck.Xunit" Version="2.10.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />

--- a/src/Petabridge.Tracing.Zipkin.Tests/Serialization/JsonSerializationSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Serialization/JsonSerializationSpecs.cs
@@ -66,8 +66,12 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
             }
         }
 
+#if !DEBUG
         [Fact(DisplayName = "Should be able to serialize simple span into a valid Zipkin-friendly JSON format.",
             Skip = "Weird environmental stuff on build server.")]
+#else // want to be able to run this spec locally
+        [Fact(DisplayName = "Should be able to serialize simple span into a valid Zipkin-friendly JSON format.")]
+#endif
         public void ShouldMapSingleSpanIntoValidJson()
         {
             var json = @"

--- a/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
+++ b/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
@@ -16,7 +16,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.3.5" />
+    <PackageReference Include="Akka" Version="1.3.6" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="OpenTracing" Version="0.11.0" />

--- a/src/Petabridge.Tracing.Zipkin/Reporting/Http/ZipkinHttpSpanReporter.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/Http/ZipkinHttpSpanReporter.cs
@@ -40,7 +40,7 @@ namespace Petabridge.Tracing.Zipkin.Reporting.Http
             // give it a chance to cleanup
             _reporterActorRef.GracefulStop(TimeSpan.FromSeconds(5)).Wait();
 
-            // then optionall terminate ActorSystem
+            // then optionally terminate ActorSystem
             _ownedActorSystem?.Terminate().Wait();
         }
 

--- a/src/Petabridge.Tracing.Zipkin/Span.cs
+++ b/src/Petabridge.Tracing.Zipkin/Span.cs
@@ -45,8 +45,8 @@ namespace Petabridge.Tracing.Zipkin
         private List<Annotation> _annotations;
         private Dictionary<string, string> _tags;
 
-        public Span(IZipkinTracer tracer, string operationName, SpanContext context, DateTimeOffset started,
-            SpanKind? kind = null, Endpoint localEndpoint = null)
+        public Span(IZipkinTracer tracer, string operationName, IZipkinSpanContext context, DateTimeOffset started,
+            SpanKind? kind = null, Endpoint localEndpoint = null, Dictionary<string, string> tags = null)
         {
             _tracer = tracer;
             OperationName = operationName;
@@ -54,6 +54,7 @@ namespace Petabridge.Tracing.Zipkin
             Started = started;
             SpanKind = kind;
             LocalEndpoint = localEndpoint ?? _tracer.LocalEndpoint;
+            _tags = tags;
         }
 
         /// <summary>
@@ -102,6 +103,7 @@ namespace Petabridge.Tracing.Zipkin
             Finish();
         }
 
+        /// <inheritdoc />
         /// <summary>
         ///     Optional. The type of span for this operation. Defaults to <c>null</c>.
         /// </summary>
@@ -112,18 +114,21 @@ namespace Petabridge.Tracing.Zipkin
         /// </summary>
         public IZipkinSpanContext TypedContext { get; }
 
+        /// <inheritdoc />
         /// <summary>
-        ///     Indicates if the <see cref="Span" /> is being used to during debugging.
+        ///     Indicates if the <see cref="T:Petabridge.Tracing.Zipkin.Span" /> is being used to during debugging.
         /// </summary>
         public bool Debug => TypedContext.Debug;
 
+        /// <inheritdoc />
         /// <summary>
-        ///     Indicates if the current <see cref="Span" /> is shared among many other traces.
+        ///     Indicates if the current <see cref="T:Petabridge.Tracing.Zipkin.Span" /> is shared among many other traces.
         /// </summary>
         public bool Shared => TypedContext.Shared;
 
+        /// <inheritdoc />
         /// <summary>
-        ///     Indicates if the current <see cref="Span" /> is part of sampling.
+        ///     Indicates if the current <see cref="T:Petabridge.Tracing.Zipkin.Span" /> is part of sampling.
         /// </summary>
         public bool Sampled => TypedContext.Sampled;
 

--- a/src/Petabridge.Tracing.Zipkin/SpanBuilder.cs
+++ b/src/Petabridge.Tracing.Zipkin/SpanBuilder.cs
@@ -161,7 +161,7 @@ namespace Petabridge.Tracing.Zipkin
             return new Span(_tracer, _operationName,
                 new SpanContext(parentContext.IsEmpty() ? _tracer.IdProvider.NextTraceId() : parentContext.TraceId,
                     _tracer.IdProvider.NextSpanId(),
-                    parentContext?.SpanId, _enableDebug, _tracer.Sampler.Sampling, _shared), _start.Value, _spanKind);
+                    parentContext?.SpanId, _enableDebug, _tracer.Sampler.Sampling, _shared), _start.Value, _spanKind, tags:_initialTags);
         }
 
         public IZipkinSpanBuilder WithSpanKind(SpanKind spanKind)

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2018 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.2.1</VersionPrefix>
-    <PackageReleaseNotes>Fixed a bug that could occur during sampling where a `NoOpSpanContext` could accidentally be added as a parent under some circumstances. In these instances, we now filter these illegal span types out.</PackageReleaseNotes>
+    <VersionPrefix>0.2.2</VersionPrefix>
+    <PackageReleaseNotes>Upgraded to [Akka.NET v1.3.6](https://github.com/akkadotnet/akka.net/releases/tag/v1.3.6)
+[Fixed: Initial tags created by IZipkinSpanBuilder aren't actually passed to span](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/25)</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://github.com/petabridge/Petabridge.Tracing.Zipkin


### PR DESCRIPTION
#### 0.2.2 April 23 2018 ####
* Upgraded to [Akka.NET v1.3.6](https://github.com/akkadotnet/akka.net/releases/tag/v1.3.6)
* [Fixed: Initial tags created by IZipkinSpanBuilder aren't actually passed to span](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/25)