### PR TITLE
Petabridge.Tracing.Zipkin v0.3.0 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+
+#### 0.3.0 June 12 2018 ####
+* [Upgraded to Akka.NET v1.3.8](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/42)
+* [Upgraded to OpenTracing v0.1.2](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/38) - this is a major change that involves some breaking API changes.
+
 #### 0.2.3 April 24 2018 ####
 * [Adding support for external `IScopeManager` implementations to work inside `IZipkinSpanBuilder`](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/32)
 

--- a/src/Petabridge.Tracing.Zipkin.Tests/Petabridge.Tracing.Zipkin.Tests.csproj
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Petabridge.Tracing.Zipkin.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.6" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.7" />
     <PackageReference Include="FluentAssertions" Version="5.2.0" />
     <PackageReference Include="FsCheck.Xunit" Version="2.10.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />

--- a/src/Petabridge.Tracing.Zipkin.Tests/Petabridge.Tracing.Zipkin.Tests.csproj
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Petabridge.Tracing.Zipkin.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.7" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.8" />
     <PackageReference Include="FluentAssertions" Version="5.2.0" />
     <PackageReference Include="FsCheck.Xunit" Version="2.10.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />

--- a/src/Petabridge.Tracing.Zipkin.Tests/Propagation/B3PropagatorSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Propagation/B3PropagatorSpecs.cs
@@ -27,7 +27,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Propagation
             bool debug)
         {
             var traceId = new TraceId(traceIdHigh, traceIdLow);
-            var context = new SpanContext(traceId, spanId, parentId, debug);
+            var context = new SpanContext(traceId, spanId, parentId?.ToString("x16"), debug);
             var carrier = new Dictionary<string, string>();
 
             Tracer.Inject(context, BuiltinFormats.HttpHeaders, new TextMapInjectAdapter(carrier));

--- a/src/Petabridge.Tracing.Zipkin.Tests/Serialization/JsonSerializationSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Serialization/JsonSerializationSpecs.cs
@@ -173,7 +173,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
             var endTime = startTime.AddMilliseconds(10);
             var expectedBytes = Encoding.UTF8.GetBytes(json);
 
-            var parentId = 11210001;
+            var parentId = 11210001.ToString("x16");
 
             var span = new Span(Tracer, "op1",
                     new SpanContext(new TraceId(7776525154056436086, 6707114971141086261), -7118946577185884628,

--- a/src/Petabridge.Tracing.Zipkin/IZipkinSpanBuilder.cs
+++ b/src/Petabridge.Tracing.Zipkin/IZipkinSpanBuilder.cs
@@ -6,6 +6,7 @@
 
 using System;
 using OpenTracing;
+using OpenTracing.Tag;
 
 namespace Petabridge.Tracing.Zipkin
 {
@@ -27,6 +28,13 @@ namespace Petabridge.Tracing.Zipkin
         new IZipkinSpanBuilder WithTag(string key, int value);
 
         new IZipkinSpanBuilder WithTag(string key, double value);
+        new IZipkinSpanBuilder WithTag(BooleanTag tag, bool value);
+
+        new IZipkinSpanBuilder WithTag(IntOrStringTag tag, string value);
+
+        new IZipkinSpanBuilder WithTag(IntTag tag, int value);
+
+        new IZipkinSpanBuilder WithTag(StringTag tag, string value);
 
         new IZipkinSpanBuilder WithStartTimestamp(DateTimeOffset timestamp);
 

--- a/src/Petabridge.Tracing.Zipkin/IZipkinSpanContext.cs
+++ b/src/Petabridge.Tracing.Zipkin/IZipkinSpanContext.cs
@@ -19,18 +19,12 @@ namespace Petabridge.Tracing.Zipkin
         ///     The trace ID. Intended to be shared across spans for
         ///     a single logical trace.
         /// </summary>
-        TraceId TraceId { get; }
-
-        /// <summary>
-        ///     The span ID. Used to identify a single atomic operation that is being
-        ///     tracked as part of an ongoing trace.
-        /// </summary>
-        long SpanId { get; }
+        TraceId ZipkinTraceId { get; }
 
         /// <summary>
         ///     Optional. Identify of the parent span if there is one.
         /// </summary>
-        long? ParentId { get; }
+        string ParentId { get; }
 
         /// <summary>
         ///     Indicates if this is a Debug trace or not.

--- a/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
+++ b/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
@@ -8,12 +8,9 @@
   </PropertyGroup>
 
 
-  <ItemGroup>
-    <Compile Remove="Scopes\**" />
-    <EmbeddedResource Remove="Scopes\**" />
-    <None Remove="Scopes\**" />
-  </ItemGroup>
-
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard2.0\Petabridge.Tracing.Zipkin.xml</DocumentationFile>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Akka" Version="1.3.6" />

--- a/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
+++ b/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.3.7" />
+    <PackageReference Include="Akka" Version="1.3.8" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="OpenTracing" Version="0.12.0" />

--- a/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
+++ b/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Akka" Version="1.3.7" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="OpenTracing" Version="0.11.0" />
+    <PackageReference Include="OpenTracing" Version="0.12.0" />
     <PackageReference Include="Phobos.Actor.Common" Version="1.0.0" />
   </ItemGroup>
 

--- a/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
+++ b/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.3.6" />
+    <PackageReference Include="Akka" Version="1.3.7" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="OpenTracing" Version="0.11.0" />

--- a/src/Petabridge.Tracing.Zipkin/Propagation/B3Propagator.cs
+++ b/src/Petabridge.Tracing.Zipkin/Propagation/B3Propagator.cs
@@ -27,10 +27,10 @@ namespace Petabridge.Tracing.Zipkin.Propagation
 
         public void Inject(SpanContext context, ITextMap carrier)
         {
-            carrier.Set(B3TraceId, context.TraceId.ToString());
-            carrier.Set(B3SpanId, context.SpanId.ToString("x16"));
+            carrier.Set(B3TraceId, context.TraceId);
+            carrier.Set(B3SpanId, context.SpanId);
             if (context.ParentId != null)
-                carrier.Set(B3ParentId, context.ParentId.Value.ToString("x16"));
+                carrier.Set(B3ParentId, context.ParentId);
 
             if (context.Debug)
             {
@@ -86,7 +86,7 @@ namespace Petabridge.Tracing.Zipkin.Propagation
                         break;
                 }
 
-            return new SpanContext(traceId, spanId, parentId, debug, sampled, shared);
+            return new SpanContext(traceId, spanId, parentId?.ToString("x16"), debug, sampled, shared);
         }
     }
 }

--- a/src/Petabridge.Tracing.Zipkin/Reporting/JsonSpanSerializer.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/JsonSpanSerializer.cs
@@ -83,14 +83,14 @@ namespace Petabridge.Tracing.Zipkin.Reporting
 
             // meta-data
             writer.WritePropertyName(TraceId);
-            writer.WriteValue(span.TypedContext.TraceId.ToString());
+            writer.WriteValue(span.TypedContext.TraceId);
             writer.WritePropertyName(SpanId);
-            var spanId = span.TypedContext.SpanId.ToString("x16");
+            var spanId = span.TypedContext.SpanId;
             writer.WriteValue(spanId);
-            if (span.TypedContext.ParentId.HasValue)
+            if (!string.IsNullOrEmpty(span.TypedContext.ParentId))
             {
                 writer.WritePropertyName(ParentId);
-                writer.WriteValue(span.TypedContext.ParentId.Value.ToString("x16"));
+                writer.WriteValue(span.TypedContext.ParentId);
             }
 
             writer.WritePropertyName(OperationName);

--- a/src/Petabridge.Tracing.Zipkin/Span.cs
+++ b/src/Petabridge.Tracing.Zipkin/Span.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using OpenTracing;
+using OpenTracing.Tag;
 
 namespace Petabridge.Tracing.Zipkin
 {
@@ -154,6 +155,36 @@ namespace Petabridge.Tracing.Zipkin
             return SetTag(key, Convert.ToString(value, CultureInfo.InvariantCulture));
         }
 
+        public ISpan SetTag(BooleanTag tag, bool value)
+        {
+            return SetTag(tag.Key, value);
+        }
+
+        public ISpan SetTag(IntOrStringTag tag, string value)
+        {
+            return SetTag(tag.Key, value);
+        }
+
+        public ISpan SetTag(IntTag tag, int value)
+        {
+            return SetTag(tag.Key, value);
+        }
+
+        public ISpan SetTag(StringTag tag, string value)
+        {
+            return SetTag(tag.Key, value);
+        }
+
+        public ISpan Log(IEnumerable<KeyValuePair<string, object>> fields)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields)
+        {
+            throw new NotImplementedException();
+        }
+
         public ISpan Log(IDictionary<string, object> fields)
         {
             return Log(_tracer.TimeProvider.Now, MergeFields(fields));
@@ -227,7 +258,7 @@ namespace Petabridge.Tracing.Zipkin
             return this;
         }
 
-        private static string MergeFields(IDictionary<string, object> fields)
+        private static string MergeFields(IEnumerable<KeyValuePair<string, object>> fields)
         {
             return string.Join(" ", fields.Select(entry => entry.Key + ":" + entry.Value));
         }

--- a/src/Petabridge.Tracing.Zipkin/SpanBuilder.cs
+++ b/src/Petabridge.Tracing.Zipkin/SpanBuilder.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using OpenTracing;
+using OpenTracing.Tag;
 using Petabridge.Tracing.Zipkin.Tracers;
 using Petabridge.Tracing.Zipkin.Util;
 
@@ -83,9 +84,54 @@ namespace Petabridge.Tracing.Zipkin
             return WithTag(key, value);
         }
 
+        public IZipkinSpanBuilder WithTag(BooleanTag tag, bool value)
+        {
+            return WithTag(tag.Key, value);
+        }
+
+        public IZipkinSpanBuilder WithTag(IntOrStringTag tag, string value)
+        {
+            return WithTag(tag.Key, value);
+        }
+
+        public IZipkinSpanBuilder WithTag(IntTag tag, int value)
+        {
+            return WithTag(tag.Key, value);
+        }
+
+        public IZipkinSpanBuilder WithTag(StringTag tag, string value)
+        {
+            return WithTag(tag.Key, value);
+        }
+
+        ISpanBuilder ISpanBuilder.WithTag(BooleanTag tag, bool value)
+        {
+            return WithTag(tag, value);
+        }
+
+        ISpanBuilder ISpanBuilder.WithTag(IntOrStringTag tag, string value)
+        {
+            return WithTag(tag, value);
+        }
+
+        ISpanBuilder ISpanBuilder.WithTag(IntTag tag, int value)
+        {
+            return WithTag(tag, value);
+        }
+
+        ISpanBuilder ISpanBuilder.WithTag(StringTag tag, string value)
+        {
+            return WithTag(tag, value);
+        }
+
         ISpanBuilder ISpanBuilder.WithStartTimestamp(DateTimeOffset timestamp)
         {
             return WithStartTimestamp(timestamp);
+        }
+
+        public IScope StartActive()
+        {
+            return StartActive(true);
         }
 
         public IZipkinSpanBuilder AsChildOf(ISpan parent)
@@ -158,8 +204,9 @@ namespace Petabridge.Tracing.Zipkin
             if (_tracer.Sampler.Sampling && !includedInSample)
                 return NoOpZipkinSpan.Instance;
 
+
             return new Span(_tracer, _operationName,
-                new SpanContext(parentContext.IsEmpty() ? _tracer.IdProvider.NextTraceId() : parentContext.TraceId,
+                new SpanContext(parentContext.IsEmpty() ? _tracer.IdProvider.NextTraceId() : parentContext.ZipkinTraceId,
                     _tracer.IdProvider.NextSpanId(),
                     parentContext?.SpanId, _enableDebug, _tracer.Sampler.Sampling, _shared), _start.Value, _spanKind, tags:_initialTags);
         }
@@ -222,8 +269,8 @@ namespace Petabridge.Tracing.Zipkin
 
             public override bool Equals(object obj)
             {
-                if (ReferenceEquals(null, obj)) return false;
-                return obj is SpanReference && Equals((SpanReference) obj);
+                if (obj is null) return false;
+                return obj is SpanReference reference && Equals(reference);
             }
 
             public override int GetHashCode()

--- a/src/Petabridge.Tracing.Zipkin/SpanContext.cs
+++ b/src/Petabridge.Tracing.Zipkin/SpanContext.cs
@@ -14,10 +14,17 @@ namespace Petabridge.Tracing.Zipkin
     /// </summary>
     public sealed class SpanContext : IZipkinSpanContext
     {
-        public SpanContext(TraceId traceId, long spanId, long? parentId = null, bool debug = false,
+        public SpanContext(TraceId traceId, long spanId, string parentId = null, bool debug = false,
+            bool sampled = false, bool shared = false) 
+            : this(traceId, spanId.ToString("x16"), parentId, 
+                debug, sampled, shared)
+        {
+        }
+
+        public SpanContext(TraceId traceId, string spanId, string parentId = null, bool debug = false,
             bool sampled = false, bool shared = false)
         {
-            TraceId = traceId;
+            ZipkinTraceId = traceId;
             SpanId = spanId;
             ParentId = parentId;
             Debug = debug;
@@ -25,22 +32,26 @@ namespace Petabridge.Tracing.Zipkin
             Shared = shared;
         }
 
+        /// <inheritdoc />
         /// <summary>
         ///     The trace ID. Intended to be shared across spans for
         ///     a single logical trace.
         /// </summary>
-        public TraceId TraceId { get; }
+        public TraceId ZipkinTraceId { get; }
+
+        /// <inheritdoc />
+        public string TraceId => ZipkinTraceId.ToString();
 
         /// <summary>
         ///     The span ID. Used to identify a single atomic operation that is being
         ///     tracked as part of an ongoing trace.
         /// </summary>
-        public long SpanId { get; }
+        public string SpanId { get; }
 
         /// <summary>
         ///     Optional. Identify of the parent span if there is one.
         /// </summary>
-        public long? ParentId { get; }
+        public string ParentId { get; }
 
         /// <summary>
         ///     Indicates if this is a Debug trace or not.
@@ -71,7 +82,7 @@ namespace Petabridge.Tracing.Zipkin
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             return obj is SpanContext && Equals((SpanContext) obj);
         }
@@ -80,7 +91,7 @@ namespace Petabridge.Tracing.Zipkin
         {
             unchecked
             {
-                var hashCode = TraceId.GetHashCode();
+                var hashCode = ZipkinTraceId.GetHashCode();
                 hashCode = (hashCode * 397) ^ SpanId.GetHashCode();
                 hashCode = (hashCode * 397) ^ ParentId.GetHashCode();
                 return hashCode;

--- a/src/Petabridge.Tracing.Zipkin/Tracers/NoOpZipkinSpan.cs
+++ b/src/Petabridge.Tracing.Zipkin/Tracers/NoOpZipkinSpan.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using OpenTracing;
+using OpenTracing.Tag;
 
 namespace Petabridge.Tracing.Zipkin.Tracers
 {
@@ -34,6 +35,36 @@ namespace Petabridge.Tracing.Zipkin.Tracers
         }
 
         public ISpan SetTag(string key, double value)
+        {
+            return this;
+        }
+
+        public ISpan SetTag(BooleanTag tag, bool value)
+        {
+            return this;
+        }
+
+        public ISpan SetTag(IntOrStringTag tag, string value)
+        {
+            return this;
+        }
+
+        public ISpan SetTag(IntTag tag, int value)
+        {
+            return this;
+        }
+
+        public ISpan SetTag(StringTag tag, string value)
+        {
+            return this;
+        }
+
+        public ISpan Log(IEnumerable<KeyValuePair<string, object>> fields)
+        {
+            return this;
+        }
+
+        public ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields)
         {
             return this;
         }

--- a/src/Petabridge.Tracing.Zipkin/Tracers/NoOpZipkinSpanContext.cs
+++ b/src/Petabridge.Tracing.Zipkin/Tracers/NoOpZipkinSpanContext.cs
@@ -32,9 +32,10 @@ namespace Petabridge.Tracing.Zipkin.Tracers
             return ReferenceEquals(other, Instance);
         }
 
-        public TraceId TraceId => new TraceId(0, 0);
-        public long SpanId => 0;
-        public long? ParentId => null;
+        public TraceId ZipkinTraceId => new TraceId(0, 0);
+        public string TraceId => ZipkinTraceId.ToString();
+        public string SpanId => "0";
+        public string ParentId => null;
         public bool Debug => true;
         public bool Sampled => false;
         public bool Shared => true;

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2018 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.2.3</VersionPrefix>
-    <PackageReleaseNotes>[Adding support for external `IScopeManager` implementations to work inside `IZipkinSpanBuilder`](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/32)</PackageReleaseNotes>
+    <VersionPrefix>0.3.0</VersionPrefix>
+    <PackageReleaseNotes>[Upgraded to Akka.NET v1.3.8](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/42)
+[Upgraded to OpenTracing v0.1.2](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/38) - this is a major change that involves some breaking API changes.</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://github.com/petabridge/Petabridge.Tracing.Zipkin

--- a/src/common.props
+++ b/src/common.props
@@ -15,7 +15,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
-    <XunitVersion>2.3.0</XunitVersion>
-    <TestSdkVersion>15.3.0</TestSdkVersion>
+    <XunitVersion>2.3.1</XunitVersion>
+    <TestSdkVersion>15.7.2</TestSdkVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### 0.3.0 June 12 2018 ####
* [Upgraded to Akka.NET v1.3.8](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/42)
* [Upgraded to OpenTracing v0.1.2](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/38) - this is a major change that involves some breaking API changes.