### PR TITLE
adds support for sampling to be done externally

### DIFF
--- a/src/Petabridge.Tracing.Zipkin.Tests/Sampling/ExternalSamplingSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Sampling/ExternalSamplingSpecs.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using Petabridge.Tracing.Zipkin.Sampling;
+using Petabridge.Tracing.Zipkin.Tracers;
+using Xunit;
+
+namespace Petabridge.Tracing.Zipkin.Tests.Sampling
+{
+    public class ExternalSamplingSpecs
+    {
+        public ExternalSamplingSpecs()
+        {
+            Tracer = new MockZipkinTracer(sampler:ExternalSampling.Instance);
+        }
+
+        protected readonly MockZipkinTracer Tracer;
+
+        [Fact(DisplayName = "Sampling should be enabled by default")]
+        public void SpansShouldHaveSamplingSetToEnabledByDefault()
+        {
+            var span = Tracer.BuildSpan("foo").Start();
+            span.Finish();
+
+            span.Sampled.Should().BeTrue();
+        }
+    }
+}

--- a/src/Petabridge.Tracing.Zipkin/Sampling/ExternalSampling.cs
+++ b/src/Petabridge.Tracing.Zipkin/Sampling/ExternalSampling.cs
@@ -1,0 +1,25 @@
+﻿namespace Petabridge.Tracing.Zipkin.Sampling
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// Used when sampling is running, but it's driven by an external engine
+    /// rather than anything internal to this Zipkin driver itself.
+    /// </summary>
+    public sealed class ExternalSampling : ITraceSampler
+    {
+        public static readonly ExternalSampling Instance = new ExternalSampling();
+        private ExternalSampling() { }
+
+        public bool Sampling { get; } = true;
+        public bool IncludeInSample(string operationName)
+        {
+            /*
+             * We return "true" here because if the code reached this stage,
+             * the sampling already occurred at a level above the Zipkin driver.
+             *
+             * So we include any traces that make it here in the sample.
+             */
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
This PR allows sampling to occur at a level above the driver, if requested, and still makes sure that all of the appropriate Zipkin metadata is tagged as such.