### PR TITLE
v0.3.2 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 0.3.2 July 30 2018 ####
+* [Implemented some missing OpenTracing v0.1.2 APIs](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/51).
+
 #### 0.3.1 July 13 2018 ####
 * [Added `ExternalSampling`](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/46) - which allows the driver to accept sampling decisions made outside of the driver itself.
 * [Added NBench performance specifications](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/47) and [Dockerized integration tests](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/41).

--- a/src/Petabridge.Tracing.Zipkin/Span.cs
+++ b/src/Petabridge.Tracing.Zipkin/Span.cs
@@ -177,12 +177,12 @@ namespace Petabridge.Tracing.Zipkin
 
         public ISpan Log(IEnumerable<KeyValuePair<string, object>> fields)
         {
-            throw new NotImplementedException();
+            return Log(_tracer.TimeProvider.Now, MergeFields(fields));
         }
 
         public ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields)
         {
-            throw new NotImplementedException();
+            return Log(timestamp, MergeFields(fields));
         }
 
         public ISpan Log(IDictionary<string, object> fields)

--- a/src/common.props
+++ b/src/common.props
@@ -2,9 +2,8 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2018 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.3.1</VersionPrefix>
-    <PackageReleaseNotes>[Added `ExternalSampling`](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/46) - which allows the driver to accept sampling decisions made outside of the driver itself.
-[Added NBench performance specifications](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/47) and [Dockerized integration tests](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/41).</PackageReleaseNotes>
+    <VersionPrefix>0.3.2</VersionPrefix>
+    <PackageReleaseNotes>[Implemented some missing OpenTracing v0.1.2 APIs](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/51).</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://github.com/petabridge/Petabridge.Tracing.Zipkin


### PR DESCRIPTION
#### 0.3.2 July 30 2018 ####
* [Implemented some missing OpenTracing v0.1.2 APIs](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/51).
