### PR TITLE
Extract null trace when none found during B3Propagator.Extract

### DIFF
--- a/src/Petabridge.Tracing.Zipkin.Integration.Tests/ZipkinHttpIntegrationSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Integration.Tests/ZipkinHttpIntegrationSpecs.cs
@@ -69,7 +69,7 @@ namespace Petabridge.Tracing.Zipkin.Integration.Tests
             var traceResp =
                 await _zipkinClient.GetAsync(fullUri);
 
-            traceResp.IsSuccessStatusCode.Should().BeTrue();
+            traceResp.IsSuccessStatusCode.Should().BeTrue($"Expected success status code, but instead found [{traceResp.StatusCode}][{traceResp.ReasonPhrase}]");
 
             var json = await traceResp.Content.ReadAsStringAsync();
             var traces = ZipkinDeserializer.Deserialize(json);

--- a/src/Petabridge.Tracing.Zipkin.Integration.Tests/ZipkinHttpIntegrationSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Integration.Tests/ZipkinHttpIntegrationSpecs.cs
@@ -57,6 +57,7 @@ namespace Petabridge.Tracing.Zipkin.Integration.Tests
                 ScopeManager = new AsyncLocalScopeManager()
             });
 
+            string traceId;
             Span parentSpan = null;
             Span childSpan = null;
 
@@ -67,6 +68,8 @@ namespace Petabridge.Tracing.Zipkin.Integration.Tests
                 {
                     childSpan = (Span)childScope.Span;
                 }
+
+                traceId = parentSpan.TypedContext.TraceId;
             }
 
             // sanity check
@@ -76,12 +79,42 @@ namespace Petabridge.Tracing.Zipkin.Integration.Tests
             // create an HTTP reporting engine
             var httpReporter = new ZipkinHttpApiTransmitter(_zipkinClient, ZipkinHttpApiTransmitter.GetFullZipkinUri(_httpBaseUri.AbsoluteUri));
 
-            // manually transmit data to Zipkin
+            // manually transmit data to Zipkin for parent span
             var resp1 = await httpReporter.TransmitSpans(new[] {parentSpan}, TimeSpan.FromSeconds(3));
-            var requestMsg = resp1.RequestMessage.Content.ReadAsStringAsync();
-            var responseMsg = await resp1.Content.ReadAsStringAsync();
             resp1.IsSuccessStatusCode.Should().BeTrue(
                 $"Expected success status code, but instead found [{resp1.StatusCode}][{resp1.ReasonPhrase}]");
+
+            // manually transmit data to Zipkin for child span
+            var resp2 = await httpReporter.TransmitSpans(new[] {childSpan}, TimeSpan.FromSeconds(3));
+            resp2.IsSuccessStatusCode.Should().BeTrue(
+                $"Expected success status code, but instead found [{resp2.StatusCode}][{resp2.ReasonPhrase}]");
+
+            var fullUri = new Uri(_httpBaseUri, $"api/v2/trace/{traceId}/");
+            HttpResponseMessage traceResp = null;
+            var retries = 3;
+            for (var i = 1; i <= retries; i++)
+            {
+                try
+                {
+                    await Task.Delay(1000); // give it some time to get uploaded
+                    traceResp =
+                        await _zipkinClient.GetAsync(fullUri);
+
+                    traceResp.IsSuccessStatusCode.Should()
+                        .BeTrue(
+                            $"Expected success status code, but instead found [{traceResp.StatusCode}][{traceResp.ReasonPhrase}]");
+                }
+                catch (Exception ex)
+                {
+                    if (i == retries)
+                        throw;
+                }
+            }
+
+            var json = await traceResp.Content.ReadAsStringAsync();
+            var traces = ZipkinDeserializer.Deserialize(json);
+
+            traces.Count.Should().Be(2);
         }
 
         [Fact(DisplayName = "End2End: Should be able to post Trace to Zipkin")]

--- a/src/Petabridge.Tracing.Zipkin.Tests.Performance/SpanSerializerSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests.Performance/SpanSerializerSpecs.cs
@@ -31,7 +31,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Performance
 
             // create a reasonably complex span
             var span = new Span(_mockTracer, "op1",
-                    new SpanContext(new TraceId(7776525154056436086, 6707114971141086261), -7118946577185884628, null,
+                    new SpanContext(new TraceId(7776525154056436086, 6707114971141086261), "-7118946577185884628", null,
                         true),
                     startTime, SpanKind.CLIENT)
                 .SetRemoteEndpoint(new Endpoint("actorsystem", "127.0.0.1", 8009)).SetTag("foo1", "bar")

--- a/src/Petabridge.Tracing.Zipkin.Tests/Propagation/B3PropagatorSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Propagation/B3PropagatorSpecs.cs
@@ -43,7 +43,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Propagation
         public Property ShouldSupportSamplingStatusViaB3(bool debug, bool sampled)
         {
             var traceId = Tracer.IdProvider.NextTraceId();
-            var context = new SpanContext(traceId, Tracer.IdProvider.NextSpanId().ToString("x16"), null, debug, sampled);
+            var context = new SpanContext(traceId, Tracer.IdProvider.NextSpanId(), null, debug, sampled);
             var carrier = new Dictionary<string, string>();
 
             Tracer.Inject(context, BuiltinFormats.HttpHeaders, new TextMapInjectAdapter(carrier));

--- a/src/Petabridge.Tracing.Zipkin.Tests/Propagation/B3PropagatorSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Propagation/B3PropagatorSpecs.cs
@@ -27,7 +27,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Propagation
             bool debug)
         {
             var traceId = new TraceId(traceIdHigh, traceIdLow);
-            var context = new SpanContext(traceId, spanId, parentId?.ToString("x16"), debug);
+            var context = new SpanContext(traceId, spanId.ToString("x16"), parentId?.ToString("x16"), debug);
             var carrier = new Dictionary<string, string>();
 
             Tracer.Inject(context, BuiltinFormats.HttpHeaders, new TextMapInjectAdapter(carrier));
@@ -41,7 +41,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Propagation
         public Property ShouldSupportSamplingStatusViaB3(bool debug, bool sampled)
         {
             var traceId = Tracer.IdProvider.NextTraceId();
-            var context = new SpanContext(traceId, Tracer.IdProvider.NextSpanId(), null, debug, sampled);
+            var context = new SpanContext(traceId, Tracer.IdProvider.NextSpanId().ToString("x16"), null, debug, sampled);
             var carrier = new Dictionary<string, string>();
 
             Tracer.Inject(context, BuiltinFormats.HttpHeaders, new TextMapInjectAdapter(carrier));

--- a/src/Petabridge.Tracing.Zipkin.Tests/Propagation/B3PropagatorSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Propagation/B3PropagatorSpecs.cs
@@ -5,11 +5,13 @@
 // -----------------------------------------------------------------------
 
 using System.Collections.Generic;
+using FluentAssertions;
 using FsCheck;
 using FsCheck.Xunit;
 using OpenTracing.Propagation;
 using Petabridge.Tracing.Zipkin.Propagation;
 using Petabridge.Tracing.Zipkin.Tracers;
+using Xunit;
 
 namespace Petabridge.Tracing.Zipkin.Tests.Propagation
 {
@@ -37,7 +39,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Propagation
             return (context == extracted).Label($"Expected [{context}] to be equal to [{extracted}]");
         }
 
-        [Property(DisplayName = "Should be ablem to inject and extract sampling data via B3")]
+        [Property(DisplayName = "Should be able to inject and extract sampling data via B3")]
         public Property ShouldSupportSamplingStatusViaB3(bool debug, bool sampled)
         {
             var traceId = Tracer.IdProvider.NextTraceId();
@@ -54,6 +56,20 @@ namespace Petabridge.Tracing.Zipkin.Tests.Propagation
                     $"Debug settings should match. Expected [{context.Debug}] but found [{extracted.Debug}]"))
                 .And((context.Sampled == extracted.Sampled).Label(
                     $"Sampled settings should match. Expected [{context.Sampled}] but found [{extracted.Sampled}]"));
+        }
+
+        /// <summary>
+        /// Fix for https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/55
+        /// </summary>
+        [Fact(DisplayName = "B3Propagator should not extract SpanContext when none found")]
+        public void ShouldNotExtractAnyTraceIdWhenNoneFound()
+        {
+            // pass in an empty carrier
+            var carrier = new Dictionary<string, string>();
+            var extracted =
+                (SpanContext)Tracer.Extract(BuiltinFormats.HttpHeaders, new TextMapExtractAdapter(carrier));
+
+            extracted.Should().BeNull();
         }
     }
 }

--- a/src/Petabridge.Tracing.Zipkin.Tests/Serialization/JsonSerializationSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Serialization/JsonSerializationSpecs.cs
@@ -130,7 +130,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
             DisplayName =
                 "Should be able to serialize a span with a defined parent into a valid Zipkin-friendly JSON format."
            )]
-        public void ShouldMapSpanWithparentIntoValidJson()
+        public void ShouldMapSpanWithParentIntoValidJson()
         {
             var json = @"
                 [

--- a/src/Petabridge.Tracing.Zipkin.Tests/Serialization/JsonSerializationSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Serialization/JsonSerializationSpecs.cs
@@ -30,7 +30,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
             var expectedStr = Encoding.UTF8.GetString(expected).Trim();
             var actualObj = JArray.Parse(actualStr).Children<JObject>();
             var expectedObj = JArray
-                .Parse(expectedStr, new JsonLoadSettings {LineInfoHandling = LineInfoHandling.Ignore})
+                .Parse(expectedStr, new JsonLoadSettings { LineInfoHandling = LineInfoHandling.Ignore })
                 .Children<JObject>();
             var enum1 = actualObj.GetEnumerator();
             var enum2 = expectedObj.GetEnumerator();
@@ -123,12 +123,13 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
                 .SetTag("timeInChair", "long").Log(startTime.AddMilliseconds(1), "foo");
             span.Finish(endTime);
 
-            VerifySerialization(new JsonSpanSerializer(), expectedBytes, (Span) span, Assert);
+            VerifySerialization(new JsonSpanSerializer(), expectedBytes, (Span)span, Assert);
         }
 
         [Fact(
             DisplayName =
-                "Should be able to serialize a span with a defined parent into a valid Zipkin-friendly JSON format."
+                "Should be able to serialize a span with a defined parent into a valid Zipkin-friendly JSON format.",
+            Skip = "Weird environmental stuff on build server."
            )]
         public void ShouldMapSpanWithParentIntoValidJson()
         {
@@ -185,7 +186,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
                 .SetTag("timeInChair", "long").Log(startTime.AddMilliseconds(1), "foo");
             span.Finish(endTime);
 
-            VerifySerialization(new JsonSpanSerializer(), expectedBytes, (Span) span, Assert);
+            VerifySerialization(new JsonSpanSerializer(), expectedBytes, (Span)span, Assert);
         }
     }
 }

--- a/src/Petabridge.Tracing.Zipkin.Tests/Serialization/JsonSerializationSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Serialization/JsonSerializationSpecs.cs
@@ -128,8 +128,8 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
 
         [Fact(
             DisplayName =
-                "Should be able to serialize a span with a defined parent into a valid Zipkin-friendly JSON format.",
-            Skip = "Weird environmental stuff on build server.")]
+                "Should be able to serialize a span with a defined parent into a valid Zipkin-friendly JSON format."
+           )]
         public void ShouldMapSpanWithparentIntoValidJson()
         {
             var json = @"

--- a/src/Petabridge.Tracing.Zipkin.Tests/Serialization/JsonSerializationSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Serialization/JsonSerializationSpecs.cs
@@ -115,7 +115,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
             var expectedBytes = Encoding.UTF8.GetBytes(json);
 
             var span = new Span(Tracer, "op1",
-                    new SpanContext(new TraceId(7776525154056436086, 6707114971141086261), -7118946577185884628, null,
+                    new SpanContext(new TraceId(7776525154056436086, 6707114971141086261), (-7118946577185884628).ToString("x16"), null,
                         true),
                     startTime, SpanKind.CLIENT)
                 .SetRemoteEndpoint(new Endpoint("actorsystem", "127.0.0.1", 8009)).SetTag("foo1", "bar")
@@ -176,7 +176,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
             var parentId = 11210001.ToString("x16");
 
             var span = new Span(Tracer, "op1",
-                    new SpanContext(new TraceId(7776525154056436086, 6707114971141086261), -7118946577185884628,
+                    new SpanContext(new TraceId(7776525154056436086, 6707114971141086261), (-7118946577185884628).ToString("x16"),
                         parentId,
                         true),
                     startTime, SpanKind.CLIENT)

--- a/src/Petabridge.Tracing.Zipkin.Tests/SpanContextSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/SpanContextSpecs.cs
@@ -15,7 +15,7 @@ namespace Petabridge.Tracing.Zipkin.Tests
         public void SpanContextSampledShouldAlwaysBeFalseWhenDebugEnabled()
         {
             // explicitly set both DEBUG and SAMPLED to true
-            var spanContext = new SpanContext(new TraceId(90, 0), 1, null, true, true);
+            var spanContext = new SpanContext(new TraceId(90, 0), "1", null, true, true);
             spanContext.Debug.Should().BeTrue();
             spanContext.Sampled.Should().BeFalse();
         }

--- a/src/Petabridge.Tracing.Zipkin/ISpanIdProvider.cs
+++ b/src/Petabridge.Tracing.Zipkin/ISpanIdProvider.cs
@@ -23,9 +23,9 @@ namespace Petabridge.Tracing.Zipkin
         TraceId NextTraceId();
 
         /// <summary>
-        ///     Generates a new unique identifier for a span.
+        /// Generates a new unique span id.
         /// </summary>
-        /// <returns>A new, hoepfully unique trace.</returns>
-        long NextSpanId();
+        /// <returns>A new span id.</returns>
+        string NextSpanId();
     }
 }

--- a/src/Petabridge.Tracing.Zipkin/Propagation/B3Propagator.cs
+++ b/src/Petabridge.Tracing.Zipkin/Propagation/B3Propagator.cs
@@ -49,9 +49,9 @@ namespace Petabridge.Tracing.Zipkin.Propagation
 
         public SpanContext Extract(ITextMap carrier)
         {
-            var traceId = default(TraceId);
-            long spanId = 0;
-            long? parentId = null;
+            TraceId? traceId = null;
+            string spanId = null;
+            string parentId = null;
             var debug = false;
             var sampled = false;
             const bool shared = false;
@@ -59,22 +59,16 @@ namespace Petabridge.Tracing.Zipkin.Propagation
                 switch (entry.Key)
                 {
                     case B3TraceId:
-                        if (!TraceId.TryParse(entry.Value, out traceId))
+                        if (!TraceId.TryParse(entry.Value, out var t))
                             throw new ZipkinFormatException(
                                 $"TraceId in format [{entry.Value}] is incompatible. Please use an X16 encoded 128bit or 64bit id.");
+                        traceId = t;
                         break;
                     case B3SpanId:
-                        if (!long.TryParse(entry.Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture,
-                            out spanId))
-                            throw new ZipkinFormatException(
-                                $"SpanId in format [{entry.Value}] is incompatible. Please use an X16 encoded 64bit id.");
+                        spanId = entry.Value;
                         break;
                     case B3ParentId:
-                        if (!long.TryParse(entry.Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture,
-                            out var p))
-                            throw new ZipkinFormatException(
-                                $"ParentId in format [{entry.Value}] is incompatible. Please use an X16 encoded 64bit id.");
-                        parentId = p;
+                        parentId = entry.Value;
                         break;
                     case B3Debug:
                         if (entry.Value.Equals("1"))
@@ -86,7 +80,9 @@ namespace Petabridge.Tracing.Zipkin.Propagation
                         break;
                 }
 
-            return new SpanContext(traceId, spanId, parentId?.ToString("x16"), debug, sampled, shared);
+            if(traceId != null && spanId != null) // don't care of ParentId is null or not
+                return new SpanContext(traceId.Value, spanId, parentId, debug, sampled, shared);
+            return null;
         }
     }
 }

--- a/src/Petabridge.Tracing.Zipkin/Reporting/NoOp/NoOpReporter.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/NoOp/NoOpReporter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Petabridge.Tracing.Zipkin.Reporting.NoOp
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Reporter that doesn't actually report spans. Used for unit testing.
+    /// </summary>
+    public sealed class NoOpReporter : ISpanReporter
+    {
+        public void Dispose()
+        {
+            
+        }
+
+        public void Report(Span span)
+        {
+            // no-op
+        }
+    }
+}

--- a/src/Petabridge.Tracing.Zipkin/Reporting/NoOp/NoOpReporter.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/NoOp/NoOpReporter.cs
@@ -1,19 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// -----------------------------------------------------------------------
+// <copyright file="NoOpReporter.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
 
 namespace Petabridge.Tracing.Zipkin.Reporting.NoOp
 {
     /// <summary>
-    /// INTERNAL API.
-    ///
-    /// Reporter that doesn't actually report spans. Used for unit testing.
+    ///     INTERNAL API.
+    ///     Reporter that doesn't actually report spans. Used for unit testing.
     /// </summary>
     public sealed class NoOpReporter : ISpanReporter
     {
         public void Dispose()
         {
-            
         }
 
         public void Report(Span span)

--- a/src/Petabridge.Tracing.Zipkin/SpanBuilder.cs
+++ b/src/Petabridge.Tracing.Zipkin/SpanBuilder.cs
@@ -207,7 +207,7 @@ namespace Petabridge.Tracing.Zipkin
 
             return new Span(_tracer, _operationName,
                 new SpanContext(parentContext.IsEmpty() ? _tracer.IdProvider.NextTraceId() : parentContext.ZipkinTraceId,
-                    _tracer.IdProvider.NextSpanId(),
+                    _tracer.IdProvider.NextSpanId().ToString(),
                     parentContext?.SpanId, _enableDebug, _tracer.Sampler.Sampling, _shared), _start.Value, _spanKind, tags:_initialTags);
         }
 

--- a/src/Petabridge.Tracing.Zipkin/SpanBuilder.cs
+++ b/src/Petabridge.Tracing.Zipkin/SpanBuilder.cs
@@ -207,7 +207,7 @@ namespace Petabridge.Tracing.Zipkin
 
             return new Span(_tracer, _operationName,
                 new SpanContext(parentContext.IsEmpty() ? _tracer.IdProvider.NextTraceId() : parentContext.ZipkinTraceId,
-                    _tracer.IdProvider.NextSpanId().ToString(),
+                    _tracer.IdProvider.NextSpanId(),
                     parentContext?.SpanId, _enableDebug, _tracer.Sampler.Sampling, _shared), _start.Value, _spanKind, tags:_initialTags);
         }
 

--- a/src/Petabridge.Tracing.Zipkin/SpanContext.cs
+++ b/src/Petabridge.Tracing.Zipkin/SpanContext.cs
@@ -14,6 +14,9 @@ namespace Petabridge.Tracing.Zipkin
     /// </summary>
     public sealed class SpanContext : IZipkinSpanContext
     {
+        [Obsolete("As of Petabridge.Tracing.Zipkin v0.3.0, we now support OpenTracing v0.12 and all drivers " +
+                  "are required to use strings as span and trace ids. Please use the string-based overload " +
+                  "of this constructor instead.")]
         public SpanContext(TraceId traceId, long spanId, string parentId = null, bool debug = false,
             bool sampled = false, bool shared = false) 
             : this(traceId, spanId.ToString("x16"), parentId, 

--- a/src/Petabridge.Tracing.Zipkin/SpanContext.cs
+++ b/src/Petabridge.Tracing.Zipkin/SpanContext.cs
@@ -110,5 +110,11 @@ namespace Petabridge.Tracing.Zipkin
         {
             return !Equals(left, right);
         }
+
+        public override string ToString()
+        {
+            return $"(ZipkinSpanContext: TraceId={TraceId}, SpanId={SpanId}, ParentId={ParentId}," +
+                   $"Sampled={Sampled}, Debug={Debug}, Shared={Shared})";
+        }
     }
 }

--- a/src/Petabridge.Tracing.Zipkin/Util/ThreadLocalRngSpanIdProvider.cs
+++ b/src/Petabridge.Tracing.Zipkin/Util/ThreadLocalRngSpanIdProvider.cs
@@ -32,14 +32,19 @@ namespace Petabridge.Tracing.Zipkin.Util
         public TraceId NextTraceId()
         {
             if (Use128Bit)
-                return new TraceId(NextSpanId(), NextSpanId());
-            return new TraceId(NextSpanId());
+                return new TraceId(NextSpanIdLong(), NextSpanIdLong());
+            return new TraceId(NextSpanIdLong());
         }
 
-        public long NextSpanId()
+        public long NextSpanIdLong()
         {
             Rng.Value.NextBytes(Buffers.Value);
             return BitConverter.ToInt64(Buffers.Value, 0);
+        }
+
+        public string NextSpanId()
+        {
+            return NextSpanIdLong().ToString("x16");
         }
     }
 }


### PR DESCRIPTION
fix for #55 - don't automatically assign 0 to traceId during B3 propagation