### PR TITLE
added v0.4.0 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 #### 0.4.0 August 28 2018 ###
 Added support for Zipkin's built-in Kafka span reporting capabilities, for users who are already considering operating at that kind of large scale.
 
-You can access the Kafka sampler via the following syntax:
+You can access the Kafka reporter via the following syntax:
 
 ```
 var tracer = new ZipkinTracer(new ZipkinTracerOptions(new Endpoint("AaronsAppKafka"),
@@ -12,7 +12,7 @@ var tracer = new ZipkinTracer(new ZipkinTracerOptions(new Endpoint("AaronsAppKaf
 The `ZipkinKafkaSpanReporter.Create` method will give you the ability to specify the Kafka endpoint, topic, and batching settings used by Petabridge.Tracing.Zipkin for reporting spans back to Zipkin via a Kafka topic. Normally, however, all you'll need to specify is just a set of endpoints for Kafka brokers - both Zipkin and the Petabridge.Tracing.Zipkin client use the "zipkin" topic by default.
 
 **Other Changes**
-Petabridge.Tracing.Zipkin also introduces fixes for the following bugs:
+Petabridge.Tracing.Zipkin also introduces the following changes:
 
 * [BugFix: calling ITracer.Inject with a NoOp span context causes cast exception](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/56)
 * [BugFix: B3Propagator.Extract always returns a span context even when one isn't present](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/55)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,23 @@
+#### 0.4.0 August 28 2018 ###
+Added support for Zipkin's built-in Kafka span reporting capabilities, for users who are already considering operating at that kind of large scale.
+
+You can access the Kafka sampler via the following syntax:
+
+```
+var tracer = new ZipkinTracer(new ZipkinTracerOptions(new Endpoint("AaronsAppKafka"),
+                ZipkinKafkaSpanReporter.Create(new ZipkinKafkaReportingOptions(new[] {"localhost:19092"},
+                    debugLogging: true))));
+```
+
+The `ZipkinKafkaSpanReporter.Create` method will give you the ability to specify the Kafka endpoint, topic, and batching settings used by Petabridge.Tracing.Zipkin for reporting spans back to Zipkin via a Kafka topic. Normally, however, all you'll need to specify is just a set of endpoints for Kafka brokers - both Zipkin and the Petabridge.Tracing.Zipkin client use the "zipkin" topic by default.
+
+**Other Changes**
+Petabridge.Tracing.Zipkin also introduces fixes for the following bugs:
+
+* [BugFix: calling ITracer.Inject with a NoOp span context causes cast exception](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/56)
+* [BugFix: B3Propagator.Extract always returns a span context even when one isn't present](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/55)
+* [Upgraded to use Akka.NET v1.3.9](https://github.com/akkadotnet/akka.net/releases/tag/v1.3.9)
+
 #### 0.3.2 July 30 2018 ####
 * [Implemented some missing OpenTracing v0.1.2 APIs](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/51).
 

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,20 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2018 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.3.2</VersionPrefix>
-    <PackageReleaseNotes>[Implemented some missing OpenTracing v0.1.2 APIs](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/51).</PackageReleaseNotes>
+    <VersionPrefix>0.4.0</VersionPrefix>
+    <PackageReleaseNotes>Added support for Zipkin's built-in Kafka span reporting capabilities, for users who are already considering operating at that kind of large scale.
+You can access the Kafka sampler via the following syntax:
+```
+var tracer = new ZipkinTracer(new ZipkinTracerOptions(new Endpoint("AaronsAppKafka"),
+ZipkinKafkaSpanReporter.Create(new ZipkinKafkaReportingOptions(new[] {"localhost:19092"},
+debugLogging: true))));
+```
+The `ZipkinKafkaSpanReporter.Create` method will give you the ability to specify the Kafka endpoint, topic, and batching settings used by Petabridge.Tracing.Zipkin for reporting spans back to Zipkin via a Kafka topic. Normally, however, all you'll need to specify is just a set of endpoints for Kafka brokers - both Zipkin and the Petabridge.Tracing.Zipkin client use the "zipkin" topic by default.
+Other Changes**
+Petabridge.Tracing.Zipkin also introduces fixes for the following bugs:
+[BugFix: calling ITracer.Inject with a NoOp span context causes cast exception](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/56)
+[BugFix: B3Propagator.Extract always returns a span context even when one isn't present](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/55)
+[Upgraded to use Akka.NET v1.3.9](https://github.com/akkadotnet/akka.net/releases/tag/v1.3.9)</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://github.com/petabridge/Petabridge.Tracing.Zipkin

--- a/src/common.props
+++ b/src/common.props
@@ -4,7 +4,7 @@
     <Authors>Petabridge</Authors>
     <VersionPrefix>0.4.0</VersionPrefix>
     <PackageReleaseNotes>Added support for Zipkin's built-in Kafka span reporting capabilities, for users who are already considering operating at that kind of large scale.
-You can access the Kafka sampler via the following syntax:
+You can access the Kafka reporter via the following syntax:
 ```
 var tracer = new ZipkinTracer(new ZipkinTracerOptions(new Endpoint("AaronsAppKafka"),
 ZipkinKafkaSpanReporter.Create(new ZipkinKafkaReportingOptions(new[] {"localhost:19092"},
@@ -12,7 +12,7 @@ debugLogging: true))));
 ```
 The `ZipkinKafkaSpanReporter.Create` method will give you the ability to specify the Kafka endpoint, topic, and batching settings used by Petabridge.Tracing.Zipkin for reporting spans back to Zipkin via a Kafka topic. Normally, however, all you'll need to specify is just a set of endpoints for Kafka brokers - both Zipkin and the Petabridge.Tracing.Zipkin client use the "zipkin" topic by default.
 Other Changes**
-Petabridge.Tracing.Zipkin also introduces fixes for the following bugs:
+Petabridge.Tracing.Zipkin also introduces the following changes:
 [BugFix: calling ITracer.Inject with a NoOp span context causes cast exception](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/56)
 [BugFix: B3Propagator.Extract always returns a span context even when one isn't present](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/55)
 [Upgraded to use Akka.NET v1.3.9](https://github.com/akkadotnet/akka.net/releases/tag/v1.3.9)</PackageReleaseNotes>


### PR DESCRIPTION
#### 0.4.0 August 28 2018 ###
Added support for Zipkin's built-in Kafka span reporting capabilities, for users who are already considering operating at that kind of large scale.

You can access the Kafka reporter via the following syntax:

```
var tracer = new ZipkinTracer(new ZipkinTracerOptions(new Endpoint("AaronsAppKafka"),
                ZipkinKafkaSpanReporter.Create(new ZipkinKafkaReportingOptions(new[] {"localhost:19092"},
                    debugLogging: true))));
```

The `ZipkinKafkaSpanReporter.Create` method will give you the ability to specify the Kafka endpoint, topic, and batching settings used by Petabridge.Tracing.Zipkin for reporting spans back to Zipkin via a Kafka topic. Normally, however, all you'll need to specify is just a set of endpoints for Kafka brokers - both Zipkin and the Petabridge.Tracing.Zipkin client use the "zipkin" topic by default.

**Other Changes**
Petabridge.Tracing.Zipkin also introduces fixes for the following bugs:

* [BugFix: calling ITracer.Inject with a NoOp span context causes cast exception](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/56)
* [BugFix: B3Propagator.Extract always returns a span context even when one isn't present](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/55)
* [Upgraded to use Akka.NET v1.3.9](https://github.com/akkadotnet/akka.net/releases/tag/v1.3.9)