### PR TITLE
Petabridge.Tracing.Zipkin v0.4.0 Release

### DIFF
--- a/Petabridge.Tracing.Zipkin.sln
+++ b/Petabridge.Tracing.Zipkin.sln
@@ -13,7 +13,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{96A3
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Petabridge.Tracing.Zipkin.SimpleDemo", "src\Petabridge.Tracing.Zipkin.SimpleDemo\Petabridge.Tracing.Zipkin.SimpleDemo.csproj", "{BC8D1A16-C540-4E57-A87C-4A9C66D51635}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Petabridge.Tracing.Zipkin.Integration.Tests", "src\Petabridge.Tracing.Zipkin.Integration.Tests\Petabridge.Tracing.Zipkin.Integration.Tests.csproj", "{D60BD0FB-F2EC-45A5-96A1-D18BB61A971B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Petabridge.Tracing.Zipkin.Integration.Tests", "src\Petabridge.Tracing.Zipkin.Integration.Tests\Petabridge.Tracing.Zipkin.Integration.Tests.csproj", "{D60BD0FB-F2EC-45A5-96A1-D18BB61A971B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Petabridge.Tracing.Zipkin.KafkaDemo", "src\Petabridge.Tracing.Zipkin.KafkaDemo\Petabridge.Tracing.Zipkin.KafkaDemo.csproj", "{73805042-B5ED-4E33-B169-78F5E4A97000}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,12 +43,17 @@ Global
 		{D60BD0FB-F2EC-45A5-96A1-D18BB61A971B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D60BD0FB-F2EC-45A5-96A1-D18BB61A971B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D60BD0FB-F2EC-45A5-96A1-D18BB61A971B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73805042-B5ED-4E33-B169-78F5E4A97000}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73805042-B5ED-4E33-B169-78F5E4A97000}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73805042-B5ED-4E33-B169-78F5E4A97000}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73805042-B5ED-4E33-B169-78F5E4A97000}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{BC8D1A16-C540-4E57-A87C-4A9C66D51635} = {96A3EB74-1B21-4406-9634-4A9EC1D76873}
+		{73805042-B5ED-4E33-B169-78F5E4A97000} = {96A3EB74-1B21-4406-9634-4A9EC1D76873}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A1F1130E-F0D7-49A9-8CBE-B8604EEA79CB}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 0.3.2 July 30 2018 ####
+* [Implemented some missing OpenTracing v0.1.2 APIs](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/51).
+
 #### 0.3.1 July 13 2018 ####
 * [Added `ExternalSampling`](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/46) - which allows the driver to accept sampling decisions made outside of the driver itself.
 * [Added NBench performance specifications](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/47) and [Dockerized integration tests](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/41).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,23 @@
+#### 0.4.0 August 28 2018 ###
+Added support for Zipkin's built-in Kafka span reporting capabilities, for users who are already considering operating at that kind of large scale.
+
+You can access the Kafka reporter via the following syntax:
+
+```
+var tracer = new ZipkinTracer(new ZipkinTracerOptions(new Endpoint("AaronsAppKafka"),
+                ZipkinKafkaSpanReporter.Create(new ZipkinKafkaReportingOptions(new[] {"localhost:19092"},
+                    debugLogging: true))));
+```
+
+The `ZipkinKafkaSpanReporter.Create` method will give you the ability to specify the Kafka endpoint, topic, and batching settings used by Petabridge.Tracing.Zipkin for reporting spans back to Zipkin via a Kafka topic. Normally, however, all you'll need to specify is just a set of endpoints for Kafka brokers - both Zipkin and the Petabridge.Tracing.Zipkin client use the "zipkin" topic by default.
+
+**Other Changes**
+Petabridge.Tracing.Zipkin also introduces the following changes:
+
+* [BugFix: calling ITracer.Inject with a NoOp span context causes cast exception](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/56)
+* [BugFix: B3Propagator.Extract always returns a span context even when one isn't present](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/55)
+* [Upgraded to use Akka.NET v1.3.9](https://github.com/akkadotnet/akka.net/releases/tag/v1.3.9)
+
 #### 0.3.2 July 30 2018 ####
 * [Implemented some missing OpenTracing v0.1.2 APIs](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/51).
 

--- a/src/Petabridge.Tracing.Zipkin.Integration.Tests/Http/ZipkinHttpIntegrationSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Integration.Tests/Http/ZipkinHttpIntegrationSpecs.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ZipkinHttpIntegrationSpecs.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 
@@ -63,10 +63,10 @@ namespace Petabridge.Tracing.Zipkin.Integration.Tests.Http
 
             using (var parentScope = testTracer.BuildSpan("parent").StartActive())
             {
-                parentSpan = (Span)parentScope.Span;
+                parentSpan = (Span) parentScope.Span;
                 using (var childScope = testTracer.BuildSpan("child").StartActive())
                 {
-                    childSpan = (Span)childScope.Span;
+                    childSpan = (Span) childScope.Span;
                 }
 
                 traceId = parentSpan.TypedContext.TraceId;
@@ -77,7 +77,8 @@ namespace Petabridge.Tracing.Zipkin.Integration.Tests.Http
             childSpan.TypedContext.ParentId.Should().Be(parentSpan.Context.SpanId);
 
             // create an HTTP reporting engine
-            var httpReporter = new ZipkinHttpApiTransmitter(_zipkinClient, ZipkinHttpApiTransmitter.GetFullZipkinUri(_httpBaseUri.AbsoluteUri));
+            var httpReporter = new ZipkinHttpApiTransmitter(_zipkinClient,
+                ZipkinHttpApiTransmitter.GetFullZipkinUri(_httpBaseUri.AbsoluteUri));
 
             // manually transmit data to Zipkin for parent span
             var resp1 = await httpReporter.TransmitSpans(new[] {parentSpan}, TimeSpan.FromSeconds(3));
@@ -93,7 +94,6 @@ namespace Petabridge.Tracing.Zipkin.Integration.Tests.Http
             HttpResponseMessage traceResp = null;
             var retries = 3;
             for (var i = 1; i <= retries; i++)
-            {
                 try
                 {
                     await Task.Delay(1000); // give it some time to get uploaded
@@ -109,7 +109,6 @@ namespace Petabridge.Tracing.Zipkin.Integration.Tests.Http
                     if (i == retries)
                         throw;
                 }
-            }
 
             var json = await traceResp.Content.ReadAsStringAsync();
             var traces = ZipkinDeserializer.Deserialize(json);
@@ -130,14 +129,13 @@ namespace Petabridge.Tracing.Zipkin.Integration.Tests.Http
                     active2.Span.Log("This is a nested span");
                 }
 
-                traceId = active.Span.Context.AsInstanceOf<IZipkinSpanContext>().TraceId.ToString();
+                traceId = active.Span.Context.AsInstanceOf<IZipkinSpanContext>().TraceId;
             }
 
             var fullUri = new Uri(_httpBaseUri, $"api/v2/trace/{traceId}/");
             HttpResponseMessage traceResp = null;
             var retries = 3;
             for (var i = 1; i <= retries; i++)
-            {
                 try
                 {
                     await Task.Delay(1000); // give it some time to get uploaded
@@ -148,14 +146,12 @@ namespace Petabridge.Tracing.Zipkin.Integration.Tests.Http
                         .BeTrue(
                             $"Expected success status code, but instead found [{traceResp.StatusCode}][{traceResp.ReasonPhrase}]");
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     if (i == retries)
                         throw;
                 }
-            }
-            
-            
+
 
             var json = await traceResp.Content.ReadAsStringAsync();
             var traces = ZipkinDeserializer.Deserialize(json);

--- a/src/Petabridge.Tracing.Zipkin.Integration.Tests/Http/ZipkinHttpIntegrationSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Integration.Tests/Http/ZipkinHttpIntegrationSpecs.cs
@@ -18,7 +18,7 @@ using Petabridge.Tracing.Zipkin.Reporting.NoOp;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Petabridge.Tracing.Zipkin.Integration.Tests
+namespace Petabridge.Tracing.Zipkin.Integration.Tests.Http
 {
     public class ZipkinHttpIntegrationSpecs : TestKit, IClassFixture<ZipkinFixture>
     {
@@ -117,7 +117,7 @@ namespace Petabridge.Tracing.Zipkin.Integration.Tests
             traces.Count.Should().Be(2);
         }
 
-        [Fact(DisplayName = "End2End: Should be able to post Trace to Zipkin")]
+        [Fact(DisplayName = "End2End: Should be able to post Trace to Zipkin via HTTP")]
         public async Task ShouldPostTraceToZipkin()
         {
             string traceId;

--- a/src/Petabridge.Tracing.Zipkin.Integration.Tests/Kafka/ZipkinKafkaFixture.cs
+++ b/src/Petabridge.Tracing.Zipkin.Integration.Tests/Kafka/ZipkinKafkaFixture.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Util;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using Xunit;
+
+namespace Petabridge.Tracing.Zipkin.Integration.Tests.Kafka
+{
+    public class ZipkinKafkaFixture : ZipkinFixture
+    {
+        protected const string KafkaImageName = "openzipkin/zipkin-kafka";
+        protected readonly string KafkaContainerName = $"zookeeper-kafka-{Guid.NewGuid():N}";
+
+        public string KafkaUri { get; private set; }
+
+        public int KafkaInternalPort { get; private set; }
+
+        public int KafkaExternalPort { get; private set; }
+
+        public int KafkaZooKeeperPort { get; private set; }
+
+        public override async Task InitializeAsync()
+        {
+            KafkaUri = await StartKafka();
+
+            /*
+             * Use the internal Docker port for the binding here, not the host-visible port mapping.
+             */
+            ZipkinUrl = await StartZipkinContainer(new[]{ KafkaContainerName }, new[]{$"KAFKA_BOOTSTRAP_SERVERS={KafkaContainerName}:9092" });
+            await Task.Delay(TimeSpan.FromSeconds(20));
+        }
+
+        private async Task<string> StartKafka()
+        {
+            var images = await _client.Images.ListImagesAsync(new ImagesListParameters {MatchName = KafkaImageName});
+            if (images.Count == 0)
+                await _client.Images.CreateImageAsync(
+                    new ImagesCreateParameters {FromImage = KafkaImageName, Tag = "latest"}, null,
+                    new Progress<JSONMessage>(message =>
+                    {
+                        Console.WriteLine(!string.IsNullOrEmpty(message.ErrorMessage)
+                            ? message.ErrorMessage
+                            : $"{message.ID} {message.Status} {message.ProgressMessage}");
+                    }));
+
+            KafkaInternalPort = ThreadLocalRandom.Current.Next(7000, 9000);
+            KafkaExternalPort = 19092; //ThreadLocalRandom.Current.Next(19000, 20000);
+            KafkaZooKeeperPort = ThreadLocalRandom.Current.Next(2000, 2999);
+
+            // create the container
+            await _client.Containers.CreateContainerAsync(new CreateContainerParameters
+            {
+                Image = KafkaImageName,
+                Name = KafkaContainerName,
+                Tty = true,
+                HostConfig = new HostConfig
+                {
+                    PortBindings = new Dictionary<string, IList<PortBinding>>
+                    {
+                        {
+                            "19092/tcp",
+                            new List<PortBinding>
+                            {
+                                new PortBinding
+                                {
+                                    HostPort = $"{KafkaExternalPort}"
+                                }
+                            }
+                        },
+                        {
+                            "9092/tcp",
+                            new List<PortBinding>
+                            {
+                                new PortBinding
+                                {
+                                    HostPort = $"{KafkaInternalPort}"
+                                }
+                            }
+                        },
+                        {
+                            "2181/tcp",
+                            new List<PortBinding>
+                            {
+                                new PortBinding
+                                {
+                                    HostPort = $"{KafkaZooKeeperPort}"
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+
+            // start the container
+            await _client.Containers.StartContainerAsync(KafkaContainerName, new ContainerStartParameters());
+            return $"localhost:{KafkaExternalPort}";
+        }
+
+        public override async Task DisposeAsync()
+        {
+            if (_client != null)
+            {
+                var stop1 =  _client.Containers.StopContainerAsync(_zipkinContainerName, new ContainerStopParameters());
+                var stop2 = _client.Containers.StopContainerAsync(KafkaContainerName, new ContainerStopParameters());
+                await Task.WhenAll(stop1, stop2);
+
+                var remove1 = _client.Containers.RemoveContainerAsync(_zipkinContainerName,
+                    new ContainerRemoveParameters { Force = true });
+                var remove2 = _client.Containers.RemoveContainerAsync(KafkaContainerName,
+                    new ContainerRemoveParameters { Force = true });
+                await Task.WhenAll(remove1, remove2);
+
+                _client.Dispose();
+            }
+        }
+    }
+}

--- a/src/Petabridge.Tracing.Zipkin.Integration.Tests/Kafka/ZipkinKafkaFixture.cs
+++ b/src/Petabridge.Tracing.Zipkin.Integration.Tests/Kafka/ZipkinKafkaFixture.cs
@@ -1,11 +1,14 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="ZipkinKafkaFixture.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Akka.Util;
-using Docker.DotNet;
 using Docker.DotNet.Models;
-using Xunit;
 
 namespace Petabridge.Tracing.Zipkin.Integration.Tests.Kafka
 {
@@ -29,7 +32,8 @@ namespace Petabridge.Tracing.Zipkin.Integration.Tests.Kafka
             /*
              * Use the internal Docker port for the binding here, not the host-visible port mapping.
              */
-            ZipkinUrl = await StartZipkinContainer(new[]{ KafkaContainerName }, new[]{$"KAFKA_BOOTSTRAP_SERVERS={KafkaContainerName}:9092" });
+            ZipkinUrl = await StartZipkinContainer(new[] {KafkaContainerName},
+                new[] {$"KAFKA_BOOTSTRAP_SERVERS={KafkaContainerName}:9092"});
             await Task.Delay(TimeSpan.FromSeconds(20));
         }
 
@@ -103,14 +107,14 @@ namespace Petabridge.Tracing.Zipkin.Integration.Tests.Kafka
         {
             if (_client != null)
             {
-                var stop1 =  _client.Containers.StopContainerAsync(_zipkinContainerName, new ContainerStopParameters());
+                var stop1 = _client.Containers.StopContainerAsync(_zipkinContainerName, new ContainerStopParameters());
                 var stop2 = _client.Containers.StopContainerAsync(KafkaContainerName, new ContainerStopParameters());
                 await Task.WhenAll(stop1, stop2);
 
                 var remove1 = _client.Containers.RemoveContainerAsync(_zipkinContainerName,
-                    new ContainerRemoveParameters { Force = true });
+                    new ContainerRemoveParameters {Force = true});
                 var remove2 = _client.Containers.RemoveContainerAsync(KafkaContainerName,
-                    new ContainerRemoveParameters { Force = true });
+                    new ContainerRemoveParameters {Force = true});
                 await Task.WhenAll(remove1, remove2);
 
                 _client.Dispose();

--- a/src/Petabridge.Tracing.Zipkin.Integration.Tests/Kafka/ZipkinKafkaIntegrationSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Integration.Tests/Kafka/ZipkinKafkaIntegrationSpecs.cs
@@ -1,15 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// -----------------------------------------------------------------------
+// <copyright file="ZipkinKafkaIntegrationSpecs.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 using System.Linq;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using Akka.TestKit.Xunit2;
 using Akka.Util.Internal;
 using FluentAssertions;
 using OpenTracing.Util;
 using Petabridge.Tracing.Zipkin.Integration.Tests.Serialization;
-using Petabridge.Tracing.Zipkin.Reporting.Http;
 using Petabridge.Tracing.Zipkin.Reporting.Kafka;
 using Xunit;
 using Xunit.Abstractions;
@@ -64,7 +67,7 @@ namespace Petabridge.Tracing.Zipkin.Integration.Tests.Kafka
                         active2.Span.Log("This is a nested span");
                     }
 
-                    traceId = active.Span.Context.AsInstanceOf<IZipkinSpanContext>().TraceId.ToString();
+                    traceId = active.Span.Context.AsInstanceOf<IZipkinSpanContext>().TraceId;
                 }
 
                 var fullUri = new Uri(_httpBaseUri, $"api/v2/trace/{traceId}/");
@@ -85,7 +88,6 @@ namespace Petabridge.Tracing.Zipkin.Integration.Tests.Kafka
                         throw;
                 }
             }
-
 
 
             var json = await traceResp.Content.ReadAsStringAsync();

--- a/src/Petabridge.Tracing.Zipkin.Integration.Tests/Kafka/ZipkinKafkaIntegrationSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Integration.Tests/Kafka/ZipkinKafkaIntegrationSpecs.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.TestKit.Xunit2;
+using Akka.Util.Internal;
+using FluentAssertions;
+using OpenTracing.Util;
+using Petabridge.Tracing.Zipkin.Integration.Tests.Serialization;
+using Petabridge.Tracing.Zipkin.Reporting.Http;
+using Petabridge.Tracing.Zipkin.Reporting.Kafka;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Petabridge.Tracing.Zipkin.Integration.Tests.Kafka
+{
+    public class ZipkinKafkaIntegrationSpecs : TestKit, IClassFixture<ZipkinKafkaFixture>
+    {
+        public ZipkinKafkaIntegrationSpecs(ITestOutputHelper helper, ZipkinKafkaFixture fixture) : base(output: helper)
+        {
+            _appName = Sys.Name + ZipkinAppCounter.IncrementAndGet();
+            Tracer = new ZipkinTracer(new ZipkinTracerOptions(
+                new Endpoint(_appName), ZipkinKafkaSpanReporter.Create(fixture.KafkaUri, Sys))
+            {
+                ScopeManager = new AsyncLocalScopeManager()
+            });
+
+            _httpBaseUri = new Uri($"http://{fixture.ZipkinUrl}/");
+            _zipkinClient = new HttpClient();
+        }
+
+        private readonly Uri _httpBaseUri;
+        private readonly HttpClient _zipkinClient;
+        private readonly string _appName;
+        private static readonly AtomicCounter ZipkinAppCounter = new AtomicCounter(0);
+
+        protected ZipkinTracer Tracer { get; }
+
+        protected override void AfterAll()
+        {
+            Tracer?.Dispose();
+        }
+
+        [Fact(DisplayName = "End2End: Should be able to post Trace to Zipkin via Kafka")]
+        public async Task ShouldPostTraceToZipkin()
+        {
+            HttpResponseMessage traceResp = null;
+            var retries = 3;
+            for (var i = 1; i <= retries; i++)
+            {
+                /*
+                 * Might have to try re-uploading the entire span. Takes Kafka a bit longer to spin up than stand-alone HTTP.
+                 *
+                 */
+                string traceId;
+                using (var active = Tracer.BuildSpan("bar").WithTag("foo", true).WithTag("akka.net", "1.3.8")
+                    .StartActive(true))
+                {
+                    active.Span.Log("this is an event");
+                    using (var active2 = Tracer.BuildSpan("foo").StartActive(true))
+                    {
+                        active2.Span.Log("This is a nested span");
+                    }
+
+                    traceId = active.Span.Context.AsInstanceOf<IZipkinSpanContext>().TraceId.ToString();
+                }
+
+                var fullUri = new Uri(_httpBaseUri, $"api/v2/trace/{traceId}/");
+
+                try
+                {
+                    await Task.Delay(1000); // give it some time to get uploaded
+                    traceResp =
+                        await _zipkinClient.GetAsync(fullUri);
+
+                    traceResp.IsSuccessStatusCode.Should()
+                        .BeTrue(
+                            $"Expected success status code, but instead found [{traceResp.StatusCode}][{traceResp.ReasonPhrase}]");
+                }
+                catch (Exception ex)
+                {
+                    if (i == retries)
+                        throw;
+                }
+            }
+
+
+
+            var json = await traceResp.Content.ReadAsStringAsync();
+            var traces = ZipkinDeserializer.Deserialize(json);
+
+            traces.Count.Should().Be(2);
+            var barSpan = traces.Single(x => x.name.Equals("bar"));
+            var fooSpan = traces.Single(x => x.name.Equals("foo"));
+            fooSpan.parentId.Should().Be(barSpan.id);
+        }
+    }
+}

--- a/src/Petabridge.Tracing.Zipkin.Integration.Tests/Petabridge.Tracing.Zipkin.Integration.Tests.csproj
+++ b/src/Petabridge.Tracing.Zipkin.Integration.Tests/Petabridge.Tracing.Zipkin.Integration.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.8" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.9" />
     <PackageReference Include="Docker.DotNet" Version="3.125.2" />
     <PackageReference Include="FluentAssertions" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />

--- a/src/Petabridge.Tracing.Zipkin.Integration.Tests/Serialization/Span.cs
+++ b/src/Petabridge.Tracing.Zipkin.Integration.Tests/Serialization/Span.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Span.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin.Integration.Tests/Serialization/ZipkinDeserializer.cs
+++ b/src/Petabridge.Tracing.Zipkin.Integration.Tests/Serialization/ZipkinDeserializer.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ZipkinDeserializer.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin.Integration.Tests/ZipkinHttpIntegrationSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Integration.Tests/ZipkinHttpIntegrationSpecs.cs
@@ -14,6 +14,7 @@ using FluentAssertions;
 using OpenTracing.Util;
 using Petabridge.Tracing.Zipkin.Integration.Tests.Serialization;
 using Petabridge.Tracing.Zipkin.Reporting.Http;
+using Petabridge.Tracing.Zipkin.Reporting.NoOp;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -47,7 +48,76 @@ namespace Petabridge.Tracing.Zipkin.Integration.Tests
             Tracer?.Dispose();
         }
 
-        [Fact(DisplayName = "Should be able to post Trace to Zipkin")]
+        [Fact(DisplayName = "HttpReporter: Should be able to post Trace to Zipkin")]
+        public async Task HttpReporterShouldPostCorrectlyToZipkin()
+        {
+            var testTracer = new ZipkinTracer(new ZipkinTracerOptions(
+                new Endpoint(_appName), new NoOpReporter())
+            {
+                ScopeManager = new AsyncLocalScopeManager()
+            });
+
+            string traceId;
+            Span parentSpan = null;
+            Span childSpan = null;
+
+            using (var parentScope = testTracer.BuildSpan("parent").StartActive())
+            {
+                parentSpan = (Span)parentScope.Span;
+                using (var childScope = testTracer.BuildSpan("child").StartActive())
+                {
+                    childSpan = (Span)childScope.Span;
+                }
+
+                traceId = parentSpan.TypedContext.TraceId;
+            }
+
+            // sanity check
+            parentSpan.TypedContext.ParentId.Should().BeNullOrEmpty();
+            childSpan.TypedContext.ParentId.Should().Be(parentSpan.Context.SpanId);
+
+            // create an HTTP reporting engine
+            var httpReporter = new ZipkinHttpApiTransmitter(_zipkinClient, ZipkinHttpApiTransmitter.GetFullZipkinUri(_httpBaseUri.AbsoluteUri));
+
+            // manually transmit data to Zipkin for parent span
+            var resp1 = await httpReporter.TransmitSpans(new[] {parentSpan}, TimeSpan.FromSeconds(3));
+            resp1.IsSuccessStatusCode.Should().BeTrue(
+                $"Expected success status code, but instead found [{resp1.StatusCode}][{resp1.ReasonPhrase}]");
+
+            // manually transmit data to Zipkin for child span
+            var resp2 = await httpReporter.TransmitSpans(new[] {childSpan}, TimeSpan.FromSeconds(3));
+            resp2.IsSuccessStatusCode.Should().BeTrue(
+                $"Expected success status code, but instead found [{resp2.StatusCode}][{resp2.ReasonPhrase}]");
+
+            var fullUri = new Uri(_httpBaseUri, $"api/v2/trace/{traceId}/");
+            HttpResponseMessage traceResp = null;
+            var retries = 3;
+            for (var i = 1; i <= retries; i++)
+            {
+                try
+                {
+                    await Task.Delay(1000); // give it some time to get uploaded
+                    traceResp =
+                        await _zipkinClient.GetAsync(fullUri);
+
+                    traceResp.IsSuccessStatusCode.Should()
+                        .BeTrue(
+                            $"Expected success status code, but instead found [{traceResp.StatusCode}][{traceResp.ReasonPhrase}]");
+                }
+                catch (Exception ex)
+                {
+                    if (i == retries)
+                        throw;
+                }
+            }
+
+            var json = await traceResp.Content.ReadAsStringAsync();
+            var traces = ZipkinDeserializer.Deserialize(json);
+
+            traces.Count.Should().Be(2);
+        }
+
+        [Fact(DisplayName = "End2End: Should be able to post Trace to Zipkin")]
         public async Task ShouldPostTraceToZipkin()
         {
             string traceId;
@@ -63,13 +133,29 @@ namespace Petabridge.Tracing.Zipkin.Integration.Tests
                 traceId = active.Span.Context.AsInstanceOf<IZipkinSpanContext>().TraceId.ToString();
             }
 
-            await Task.Delay(1000); // give it some time to get uploaded
-
             var fullUri = new Uri(_httpBaseUri, $"api/v2/trace/{traceId}/");
-            var traceResp =
-                await _zipkinClient.GetAsync(fullUri);
+            HttpResponseMessage traceResp = null;
+            var retries = 3;
+            for (var i = 1; i <= retries; i++)
+            {
+                try
+                {
+                    await Task.Delay(1000); // give it some time to get uploaded
+                    traceResp =
+                        await _zipkinClient.GetAsync(fullUri);
 
-            traceResp.IsSuccessStatusCode.Should().BeTrue();
+                    traceResp.IsSuccessStatusCode.Should()
+                        .BeTrue(
+                            $"Expected success status code, but instead found [{traceResp.StatusCode}][{traceResp.ReasonPhrase}]");
+                }
+                catch(Exception ex)
+                {
+                    if (i == retries)
+                        throw;
+                }
+            }
+            
+            
 
             var json = await traceResp.Content.ReadAsStringAsync();
             var traces = ZipkinDeserializer.Deserialize(json);

--- a/src/Petabridge.Tracing.Zipkin.KafkaDemo/Petabridge.Tracing.Zipkin.KafkaDemo.csproj
+++ b/src/Petabridge.Tracing.Zipkin.KafkaDemo/Petabridge.Tracing.Zipkin.KafkaDemo.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Petabridge.Tracing.Zipkin\Petabridge.Tracing.Zipkin.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Petabridge.Tracing.Zipkin.KafkaDemo/Program.cs
+++ b/src/Petabridge.Tracing.Zipkin.KafkaDemo/Program.cs
@@ -1,14 +1,22 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="Program.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 using Petabridge.Tracing.Zipkin.Reporting.Kafka;
 
 namespace Petabridge.Tracing.Zipkin.KafkaDemo
 {
-    class Program
+    internal class Program
     {
-        static void Main(string[] args)
+        private static void Main(string[] args)
         {
             var url = "http://localhost:9411";
-            var tracer = new ZipkinTracer(new ZipkinTracerOptions(new Endpoint("AaronsAppKafka"), ZipkinKafkaSpanReporter.Create(new ZipkinKafkaReportingOptions(new[]{ "localhost:19092" }, debugLogging:true))));
+            var tracer = new ZipkinTracer(new ZipkinTracerOptions(new Endpoint("AaronsAppKafka"),
+                ZipkinKafkaSpanReporter.Create(new ZipkinKafkaReportingOptions(new[] {"localhost:19092"},
+                    debugLogging: true))));
             Console.WriteLine("Connected to Zipkin at {0}", url);
             Console.WriteLine("Type some gibberish and press enter to create a trace!");
             Console.WriteLine("Type '/exit to quit.");

--- a/src/Petabridge.Tracing.Zipkin.KafkaDemo/Program.cs
+++ b/src/Petabridge.Tracing.Zipkin.KafkaDemo/Program.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Petabridge.Tracing.Zipkin.Reporting.Kafka;
+
+namespace Petabridge.Tracing.Zipkin.KafkaDemo
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var url = "http://localhost:9411";
+            var tracer = new ZipkinTracer(new ZipkinTracerOptions(new Endpoint("AaronsAppKafka"), ZipkinKafkaSpanReporter.Create(new ZipkinKafkaReportingOptions(new[]{ "localhost:19092" }, debugLogging:true))));
+            Console.WriteLine("Connected to Zipkin at {0}", url);
+            Console.WriteLine("Type some gibberish and press enter to create a trace!");
+            Console.WriteLine("Type '/exit to quit.");
+            var line = Console.ReadLine();
+            IZipkinSpan current = null;
+            while (string.IsNullOrEmpty(line) || !line.Equals("/exit"))
+            {
+                IZipkinSpanBuilder sb = null;
+                if (string.IsNullOrEmpty(line))
+                {
+                    sb = tracer.BuildSpan("no-op").WithTag("empty", true);
+                    if (current != null)
+                        current.Finish();
+                }
+                else
+                {
+                    sb = tracer.BuildSpan("actual-op").WithTag("empty", false);
+                    if (current != null)
+                    {
+                        current.Finish();
+                        sb = sb.AsChildOf(current);
+                    }
+                }
+
+                current = sb.Start();
+
+                if (!string.IsNullOrEmpty(line))
+                    current.Log(line);
+
+                line = Console.ReadLine();
+            }
+
+            current?.Finish();
+
+            tracer.Dispose();
+        }
+    }
+}

--- a/src/Petabridge.Tracing.Zipkin.SimpleDemo/Program.cs
+++ b/src/Petabridge.Tracing.Zipkin.SimpleDemo/Program.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Program.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin.Tests.Performance/Petabridge.Tracing.Zipkin.Tests.Performance.csproj
+++ b/src/Petabridge.Tracing.Zipkin.Tests.Performance/Petabridge.Tracing.Zipkin.Tests.Performance.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="NBench" Version="1.2.1" />
+    <PackageReference Include="NBench" Version="1.2.2" />
     <DotNetCliToolReference Include="dotnet-nbench" Version="1.2.1" />
   </ItemGroup>
 

--- a/src/Petabridge.Tracing.Zipkin.Tests.Performance/SpanBuilderSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests.Performance/SpanBuilderSpecs.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="SpanBuilderSpecs.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 
@@ -33,7 +33,6 @@ namespace Petabridge.Tracing.Zipkin.Tests.Performance
             for (var i = 0; i < SpanCount; i++)
                 using (_mockTracer.BuildSpan("test1").WithTag("foo", "bar").StartActive())
                 {
-                   
                 }
 
             _opsCounter.Increment(SpanCount);

--- a/src/Petabridge.Tracing.Zipkin.Tests.Performance/SpanSerializerSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests.Performance/SpanSerializerSpecs.cs
@@ -31,7 +31,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Performance
 
             // create a reasonably complex span
             var span = new Span(_mockTracer, "op1",
-                    new SpanContext(new TraceId(7776525154056436086, 6707114971141086261), -7118946577185884628, null,
+                    new SpanContext(new TraceId(7776525154056436086, 6707114971141086261), "-7118946577185884628", null,
                         true),
                     startTime, SpanKind.CLIENT)
                 .SetRemoteEndpoint(new Endpoint("actorsystem", "127.0.0.1", 8009)).SetTag("foo1", "bar")

--- a/src/Petabridge.Tracing.Zipkin.Tests.Performance/SpanSerializerSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests.Performance/SpanSerializerSpecs.cs
@@ -1,9 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// -----------------------------------------------------------------------
+// <copyright file="SpanSerializerSpecs.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NBench;
 using Petabridge.Tracing.Zipkin.Reporting;
 using Petabridge.Tracing.Zipkin.Tracers;
@@ -16,10 +18,12 @@ namespace Petabridge.Tracing.Zipkin.Tests.Performance
 
         public const int SpanCount = 100000;
 
-        private readonly MockZipkinTracer _mockTracer = new MockZipkinTracer(new Endpoint("actorsystem", "127.0.0.1", 8008));
+        private readonly MockZipkinTracer _mockTracer =
+            new MockZipkinTracer(new Endpoint("actorsystem", "127.0.0.1", 8008));
+
         private readonly ISpanSerializer _serializer = new JsonSpanSerializer();
-        private Span _testSpan;
         private Counter _opsCounter;
+        private Span _testSpan;
 
         [PerfSetup]
         public void Setup(BenchmarkContext context)
@@ -48,8 +52,10 @@ namespace Petabridge.Tracing.Zipkin.Tests.Performance
         public void SerializeSpans()
         {
             for (var i = 0; i < SpanCount; i++)
-                using(var mem = new MemoryStream())
-                _serializer.Serialize(mem, _testSpan);
+                using (var mem = new MemoryStream())
+                {
+                    _serializer.Serialize(mem, _testSpan);
+                }
 
             _opsCounter.Increment(SpanCount);
         }

--- a/src/Petabridge.Tracing.Zipkin.Tests/Bug25SpanTagsSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Bug25SpanTagsSpecs.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Bug25SpanTagsSpecs.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin.Tests/ExternalScopeManagerSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/ExternalScopeManagerSpecs.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ExternalScopeManagerSpecs.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin.Tests/Petabridge.Tracing.Zipkin.Tests.csproj
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Petabridge.Tracing.Zipkin.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.8" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.9" />
     <PackageReference Include="FluentAssertions" Version="5.2.0" />
     <PackageReference Include="FsCheck.Xunit" Version="2.10.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />

--- a/src/Petabridge.Tracing.Zipkin.Tests/Propagation/B3PropagatorSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Propagation/B3PropagatorSpecs.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="B3PropagatorSpecs.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 
@@ -19,12 +19,12 @@ namespace Petabridge.Tracing.Zipkin.Tests.Propagation
 {
     public class B3PropagatorSpecs
     {
-        public readonly MockZipkinTracer Tracer;
-
         public B3PropagatorSpecs()
         {
             Tracer = new MockZipkinTracer(propagtor: new B3Propagator());
         }
+
+        public readonly MockZipkinTracer Tracer;
 
         [Property(DisplayName = "Should be able to extract and inject spans via B3 headers")]
         public Property ShouldExtractAndInjectSpansViaB3(long traceIdHigh, long traceIdLow, long spanId, long? parentId,
@@ -61,28 +61,16 @@ namespace Petabridge.Tracing.Zipkin.Tests.Propagation
         }
 
         /// <summary>
-        /// Verify for https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/55
+        ///     Verify fix for https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/56
         /// </summary>
-        [Fact(DisplayName = "B3Propagator should not extract SpanContext when none found")]
-        public void ShouldNotExtractAnyTraceIdWhenNoneFound()
-        {
-            // pass in an empty carrier
-            var carrier = new Dictionary<string, string>();
-            var extracted =
-                (SpanContext)Tracer.Extract(BuiltinFormats.HttpHeaders, new TextMapExtractAdapter(carrier));
-
-            extracted.Should().BeNull();
-        }
-
-        /// <summary>
-        /// Verify fix for https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/56
-        /// </summary>
-        [Fact(DisplayName = "Bugfix for issue 56 - Propagator should not throw when attempting to inject non-Zipkin context.")]
+        [Fact(DisplayName =
+            "Bugfix for issue 56 - Propagator should not throw when attempting to inject non-Zipkin context.")]
         public void BugFix56NonZipkingContextShouldNotThrowUponInjectionAttempt()
         {
             // uses the MockZipkinTracer
             var carrier = new Dictionary<string, string>();
-            Tracer.Inject(NoOpZipkinSpanContext.Instance, BuiltinFormats.HttpHeaders, new TextMapInjectAdapter(carrier));
+            Tracer.Inject(NoOpZipkinSpanContext.Instance, BuiltinFormats.HttpHeaders,
+                new TextMapInjectAdapter(carrier));
             carrier.Count.Should().Be(0);
 
             // uses the real Zipkin tracer with a No-Op reporter
@@ -91,8 +79,23 @@ namespace Petabridge.Tracing.Zipkin.Tests.Propagation
             {
                 ScopeManager = new AsyncLocalScopeManager()
             });
-            testTracer.Inject(NoOpZipkinSpanContext.Instance, BuiltinFormats.HttpHeaders, new TextMapInjectAdapter(carrier));
+            testTracer.Inject(NoOpZipkinSpanContext.Instance, BuiltinFormats.HttpHeaders,
+                new TextMapInjectAdapter(carrier));
             carrier.Count.Should().Be(0);
+        }
+
+        /// <summary>
+        ///     Verify for https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/55
+        /// </summary>
+        [Fact(DisplayName = "B3Propagator should not extract SpanContext when none found")]
+        public void ShouldNotExtractAnyTraceIdWhenNoneFound()
+        {
+            // pass in an empty carrier
+            var carrier = new Dictionary<string, string>();
+            var extracted =
+                (SpanContext) Tracer.Extract(BuiltinFormats.HttpHeaders, new TextMapExtractAdapter(carrier));
+
+            extracted.Should().BeNull();
         }
     }
 }

--- a/src/Petabridge.Tracing.Zipkin.Tests/Sampling/ExternalSamplingSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Sampling/ExternalSamplingSpecs.cs
@@ -1,6 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// -----------------------------------------------------------------------
+// <copyright file="ExternalSamplingSpecs.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
 using FluentAssertions;
 using Petabridge.Tracing.Zipkin.Sampling;
 using Petabridge.Tracing.Zipkin.Tracers;
@@ -12,7 +15,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Sampling
     {
         public ExternalSamplingSpecs()
         {
-            Tracer = new MockZipkinTracer(sampler:ExternalSampling.Instance);
+            Tracer = new MockZipkinTracer(sampler: ExternalSampling.Instance);
         }
 
         protected readonly MockZipkinTracer Tracer;

--- a/src/Petabridge.Tracing.Zipkin.Tests/Sampling/NoSamplingSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Sampling/NoSamplingSpecs.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="NoSamplingSpecs.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin.Tests/Sampling/ProbabilisticSamplerSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Sampling/ProbabilisticSamplerSpecs.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ProbabilisticSamplerSpecs.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin.Tests/Serialization/JsonSerializationSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Serialization/JsonSerializationSpecs.cs
@@ -30,7 +30,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
             var expectedStr = Encoding.UTF8.GetString(expected).Trim();
             var actualObj = JArray.Parse(actualStr).Children<JObject>();
             var expectedObj = JArray
-                .Parse(expectedStr, new JsonLoadSettings {LineInfoHandling = LineInfoHandling.Ignore})
+                .Parse(expectedStr, new JsonLoadSettings { LineInfoHandling = LineInfoHandling.Ignore })
                 .Children<JObject>();
             var enum1 = actualObj.GetEnumerator();
             var enum2 = expectedObj.GetEnumerator();
@@ -115,7 +115,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
             var expectedBytes = Encoding.UTF8.GetBytes(json);
 
             var span = new Span(Tracer, "op1",
-                    new SpanContext(new TraceId(7776525154056436086, 6707114971141086261), -7118946577185884628, null,
+                    new SpanContext(new TraceId(7776525154056436086, 6707114971141086261), (-7118946577185884628).ToString("x16"), null,
                         true),
                     startTime, SpanKind.CLIENT)
                 .SetRemoteEndpoint(new Endpoint("actorsystem", "127.0.0.1", 8009)).SetTag("foo1", "bar")
@@ -123,14 +123,15 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
                 .SetTag("timeInChair", "long").Log(startTime.AddMilliseconds(1), "foo");
             span.Finish(endTime);
 
-            VerifySerialization(new JsonSpanSerializer(), expectedBytes, (Span) span, Assert);
+            VerifySerialization(new JsonSpanSerializer(), expectedBytes, (Span)span, Assert);
         }
 
         [Fact(
             DisplayName =
                 "Should be able to serialize a span with a defined parent into a valid Zipkin-friendly JSON format.",
-            Skip = "Weird environmental stuff on build server.")]
-        public void ShouldMapSpanWithparentIntoValidJson()
+            Skip = "Weird environmental stuff on build server."
+           )]
+        public void ShouldMapSpanWithParentIntoValidJson()
         {
             var json = @"
                 [
@@ -176,7 +177,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
             var parentId = 11210001.ToString("x16");
 
             var span = new Span(Tracer, "op1",
-                    new SpanContext(new TraceId(7776525154056436086, 6707114971141086261), -7118946577185884628,
+                    new SpanContext(new TraceId(7776525154056436086, 6707114971141086261), (-7118946577185884628).ToString("x16"),
                         parentId,
                         true),
                     startTime, SpanKind.CLIENT)
@@ -185,7 +186,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
                 .SetTag("timeInChair", "long").Log(startTime.AddMilliseconds(1), "foo");
             span.Finish(endTime);
 
-            VerifySerialization(new JsonSpanSerializer(), expectedBytes, (Span) span, Assert);
+            VerifySerialization(new JsonSpanSerializer(), expectedBytes, (Span)span, Assert);
         }
     }
 }

--- a/src/Petabridge.Tracing.Zipkin.Tests/Serialization/JsonSerializationSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Serialization/JsonSerializationSpecs.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="JsonSerializationSpecs.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 
@@ -30,7 +30,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
             var expectedStr = Encoding.UTF8.GetString(expected).Trim();
             var actualObj = JArray.Parse(actualStr).Children<JObject>();
             var expectedObj = JArray
-                .Parse(expectedStr, new JsonLoadSettings { LineInfoHandling = LineInfoHandling.Ignore })
+                .Parse(expectedStr, new JsonLoadSettings {LineInfoHandling = LineInfoHandling.Ignore})
                 .Children<JObject>();
             var enum1 = actualObj.GetEnumerator();
             var enum2 = expectedObj.GetEnumerator();
@@ -115,7 +115,8 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
             var expectedBytes = Encoding.UTF8.GetBytes(json);
 
             var span = new Span(Tracer, "op1",
-                    new SpanContext(new TraceId(7776525154056436086, 6707114971141086261), (-7118946577185884628).ToString("x16"), null,
+                    new SpanContext(new TraceId(7776525154056436086, 6707114971141086261),
+                        (-7118946577185884628).ToString("x16"), null,
                         true),
                     startTime, SpanKind.CLIENT)
                 .SetRemoteEndpoint(new Endpoint("actorsystem", "127.0.0.1", 8009)).SetTag("foo1", "bar")
@@ -123,14 +124,14 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
                 .SetTag("timeInChair", "long").Log(startTime.AddMilliseconds(1), "foo");
             span.Finish(endTime);
 
-            VerifySerialization(new JsonSpanSerializer(), expectedBytes, (Span)span, Assert);
+            VerifySerialization(new JsonSpanSerializer(), expectedBytes, (Span) span, Assert);
         }
 
         [Fact(
             DisplayName =
                 "Should be able to serialize a span with a defined parent into a valid Zipkin-friendly JSON format.",
             Skip = "Weird environmental stuff on build server."
-           )]
+        )]
         public void ShouldMapSpanWithParentIntoValidJson()
         {
             var json = @"
@@ -177,7 +178,8 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
             var parentId = 11210001.ToString("x16");
 
             var span = new Span(Tracer, "op1",
-                    new SpanContext(new TraceId(7776525154056436086, 6707114971141086261), (-7118946577185884628).ToString("x16"),
+                    new SpanContext(new TraceId(7776525154056436086, 6707114971141086261),
+                        (-7118946577185884628).ToString("x16"),
                         parentId,
                         true),
                     startTime, SpanKind.CLIENT)
@@ -186,7 +188,7 @@ namespace Petabridge.Tracing.Zipkin.Tests.Serialization
                 .SetTag("timeInChair", "long").Log(startTime.AddMilliseconds(1), "foo");
             span.Finish(endTime);
 
-            VerifySerialization(new JsonSpanSerializer(), expectedBytes, (Span)span, Assert);
+            VerifySerialization(new JsonSpanSerializer(), expectedBytes, (Span) span, Assert);
         }
     }
 }

--- a/src/Petabridge.Tracing.Zipkin.Tests/Serialization/SerializationSpecBase.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Serialization/SerializationSpecBase.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="SerializationSpecBase.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin.Tests/SpanContextSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/SpanContextSpecs.cs
@@ -15,7 +15,7 @@ namespace Petabridge.Tracing.Zipkin.Tests
         public void SpanContextSampledShouldAlwaysBeFalseWhenDebugEnabled()
         {
             // explicitly set both DEBUG and SAMPLED to true
-            var spanContext = new SpanContext(new TraceId(90, 0), 1, null, true, true);
+            var spanContext = new SpanContext(new TraceId(90, 0), "1", null, true, true);
             spanContext.Debug.Should().BeTrue();
             spanContext.Sampled.Should().BeFalse();
         }

--- a/src/Petabridge.Tracing.Zipkin.Tests/SpanContextSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/SpanContextSpecs.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="SpanContextSpecs.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin.Tests/SpanSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/SpanSpecs.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="SpanSpecs.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 
@@ -18,6 +18,17 @@ namespace Petabridge.Tracing.Zipkin.Tests
         }
 
         protected readonly MockZipkinTracer Tracer;
+
+        [Fact(DisplayName =
+            "If a NoOpZipkinSpanContext is added as a reference to a valid span, should just discard and not throw error")]
+        public void SamplingBugFixShouldNotThrowExceptionNoOpSpanContextAddedAsReference()
+        {
+            var span1 = NoOpZipkinSpan.Instance;
+            var span2 = Tracer.BuildSpan("foo").AsChildOf(span1).Start();
+
+            // should safely ignore the span
+            span2.TypedContext.ParentId.Should().BeNull();
+        }
 
         [Fact(DisplayName = "Should be able to create child spans")]
         public void ShouldCreateChildSpansWithSameTraceId()
@@ -78,16 +89,6 @@ namespace Petabridge.Tracing.Zipkin.Tests
 
             Tracer.CollectedSpans.TryDequeue(out var innerSpan);
             innerSpan.Debug.Should().BeTrue();
-        }
-
-        [Fact(DisplayName = "If a NoOpZipkinSpanContext is added as a reference to a valid span, should just discard and not throw error")]
-        public void SamplingBugFixShouldNotThrowExceptionNoOpSpanContextAddedAsReference()
-        {
-            var span1 = NoOpZipkinSpan.Instance;
-            var span2 = Tracer.BuildSpan("foo").AsChildOf(span1).Start();
-
-            // should safely ignore the span
-            span2.TypedContext.ParentId.Should().BeNull();
         }
     }
 }

--- a/src/Petabridge.Tracing.Zipkin.Tests/TraceIdSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/TraceIdSpecs.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="TraceIdSpecs.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin.Tests/Util/SpanExtensionsSpecs.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Util/SpanExtensionsSpecs.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="SpanExtensionsSpecs.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Annotation.cs
+++ b/src/Petabridge.Tracing.Zipkin/Annotation.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Annotation.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Endpoint.cs
+++ b/src/Petabridge.Tracing.Zipkin/Endpoint.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Endpoint.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Exceptions/ZipkinException.cs
+++ b/src/Petabridge.Tracing.Zipkin/Exceptions/ZipkinException.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ZipkinException.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Exceptions/ZipkinFormatException.cs
+++ b/src/Petabridge.Tracing.Zipkin/Exceptions/ZipkinFormatException.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ZipkinFormatException.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/ISpanIdProvider.cs
+++ b/src/Petabridge.Tracing.Zipkin/ISpanIdProvider.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ISpanIdProvider.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 
@@ -23,7 +23,7 @@ namespace Petabridge.Tracing.Zipkin
         TraceId NextTraceId();
 
         /// <summary>
-        /// Generates a new unique span id.
+        ///     Generates a new unique span id.
         /// </summary>
         /// <returns>A new span id.</returns>
         string NextSpanId();

--- a/src/Petabridge.Tracing.Zipkin/ISpanIdProvider.cs
+++ b/src/Petabridge.Tracing.Zipkin/ISpanIdProvider.cs
@@ -23,9 +23,9 @@ namespace Petabridge.Tracing.Zipkin
         TraceId NextTraceId();
 
         /// <summary>
-        ///     Generates a new unique identifier for a span.
+        /// Generates a new unique span id.
         /// </summary>
-        /// <returns>A new, hoepfully unique trace.</returns>
-        long NextSpanId();
+        /// <returns>A new span id.</returns>
+        string NextSpanId();
     }
 }

--- a/src/Petabridge.Tracing.Zipkin/ISpanReporter.cs
+++ b/src/Petabridge.Tracing.Zipkin/ISpanReporter.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ISpanReporter.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/ITimeProvider.cs
+++ b/src/Petabridge.Tracing.Zipkin/ITimeProvider.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ITimeProvider.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/ITraceSampler.cs
+++ b/src/Petabridge.Tracing.Zipkin/ITraceSampler.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ITraceSampler.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/IZipkinSpan.cs
+++ b/src/Petabridge.Tracing.Zipkin/IZipkinSpan.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="IZipkinSpan.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/IZipkinSpanBuilder.cs
+++ b/src/Petabridge.Tracing.Zipkin/IZipkinSpanBuilder.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="IZipkinSpanBuilder.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/IZipkinSpanContext.cs
+++ b/src/Petabridge.Tracing.Zipkin/IZipkinSpanContext.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="IZipkinSpanContext.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/IZipkinTracer.cs
+++ b/src/Petabridge.Tracing.Zipkin/IZipkinTracer.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="IZipkinTracer.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
+++ b/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Akka" Version="1.3.9" />
+    <PackageReference Include="Confluent.Kafka" Version="0.11.5" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="OpenTracing" Version="0.12.0" />

--- a/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
+++ b/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.3.8" />
+    <PackageReference Include="Akka" Version="1.3.9" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="OpenTracing" Version="0.12.0" />

--- a/src/Petabridge.Tracing.Zipkin/Propagation/B3Propagator.cs
+++ b/src/Petabridge.Tracing.Zipkin/Propagation/B3Propagator.cs
@@ -1,10 +1,9 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="B3Propagator.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 
-using System.Globalization;
 using OpenTracing.Propagation;
 using Petabridge.Tracing.Zipkin.Exceptions;
 
@@ -80,7 +79,7 @@ namespace Petabridge.Tracing.Zipkin.Propagation
                         break;
                 }
 
-            if(traceId != null && spanId != null) // don't care of ParentId is null or not
+            if (traceId != null && spanId != null) // don't care of ParentId is null or not
                 return new SpanContext(traceId.Value, spanId, parentId, debug, sampled, shared);
             return null;
         }

--- a/src/Petabridge.Tracing.Zipkin/Propagation/B3Propagator.cs
+++ b/src/Petabridge.Tracing.Zipkin/Propagation/B3Propagator.cs
@@ -49,9 +49,9 @@ namespace Petabridge.Tracing.Zipkin.Propagation
 
         public SpanContext Extract(ITextMap carrier)
         {
-            var traceId = default(TraceId);
-            long spanId = 0;
-            long? parentId = null;
+            TraceId? traceId = null;
+            string spanId = null;
+            string parentId = null;
             var debug = false;
             var sampled = false;
             const bool shared = false;
@@ -59,22 +59,16 @@ namespace Petabridge.Tracing.Zipkin.Propagation
                 switch (entry.Key)
                 {
                     case B3TraceId:
-                        if (!TraceId.TryParse(entry.Value, out traceId))
+                        if (!TraceId.TryParse(entry.Value, out var t))
                             throw new ZipkinFormatException(
                                 $"TraceId in format [{entry.Value}] is incompatible. Please use an X16 encoded 128bit or 64bit id.");
+                        traceId = t;
                         break;
                     case B3SpanId:
-                        if (!long.TryParse(entry.Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture,
-                            out spanId))
-                            throw new ZipkinFormatException(
-                                $"SpanId in format [{entry.Value}] is incompatible. Please use an X16 encoded 64bit id.");
+                        spanId = entry.Value;
                         break;
                     case B3ParentId:
-                        if (!long.TryParse(entry.Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture,
-                            out var p))
-                            throw new ZipkinFormatException(
-                                $"ParentId in format [{entry.Value}] is incompatible. Please use an X16 encoded 64bit id.");
-                        parentId = p;
+                        parentId = entry.Value;
                         break;
                     case B3Debug:
                         if (entry.Value.Equals("1"))
@@ -86,7 +80,9 @@ namespace Petabridge.Tracing.Zipkin.Propagation
                         break;
                 }
 
-            return new SpanContext(traceId, spanId, parentId?.ToString("x16"), debug, sampled, shared);
+            if(traceId != null && spanId != null) // don't care of ParentId is null or not
+                return new SpanContext(traceId.Value, spanId, parentId, debug, sampled, shared);
+            return null;
         }
     }
 }

--- a/src/Petabridge.Tracing.Zipkin/Propagation/IPropagator.cs
+++ b/src/Petabridge.Tracing.Zipkin/Propagation/IPropagator.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="IPropagator.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Properties/Friends.cs
+++ b/src/Petabridge.Tracing.Zipkin/Properties/Friends.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Friends.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Reporting/Http/HttpReportingActor.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/Http/HttpReportingActor.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="HttpReportingActor.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Reporting/Http/ZipkinHttpApiTransmitter.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/Http/ZipkinHttpApiTransmitter.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ZipkinHttpApiTransmitter.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.IO;
 
 namespace Petabridge.Tracing.Zipkin.Reporting.Http
 {
@@ -42,7 +41,8 @@ namespace Petabridge.Tracing.Zipkin.Reporting.Http
 
         public async Task<HttpResponseMessage> TransmitSpans(IEnumerable<Span> spans, TimeSpan timeout)
         {
-            using (var stream = SerializationStreamManager.StreamManager.GetStream("Petabridge.Tracing.Zipkin.HttpTransmitter"))
+            using (var stream =
+                SerializationStreamManager.StreamManager.GetStream("Petabridge.Tracing.Zipkin.HttpTransmitter"))
             {
                 _serializer.Serialize(stream, spans);
                 var cts = new CancellationTokenSource(timeout);

--- a/src/Petabridge.Tracing.Zipkin/Reporting/Http/ZipkinHttpApiTransmitter.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/Http/ZipkinHttpApiTransmitter.cs
@@ -28,11 +28,6 @@ namespace Petabridge.Tracing.Zipkin.Reporting.Http
         /// </summary>
         public const string SpanPostUriPath = "api/v2/spans";
 
-        /// <summary>
-        ///     Only need one of these globally, and it's thread-safe. The streams it accesses internally are inherently not safe.
-        /// </summary>
-        private static readonly RecyclableMemoryStreamManager StreamManager = new RecyclableMemoryStreamManager();
-
         private readonly HttpClient _client;
 
         private readonly ISpanSerializer _serializer = new JsonSpanSerializer();
@@ -47,7 +42,7 @@ namespace Petabridge.Tracing.Zipkin.Reporting.Http
 
         public async Task<HttpResponseMessage> TransmitSpans(IEnumerable<Span> spans, TimeSpan timeout)
         {
-            using (var stream = StreamManager.GetStream("Petabridge.Tracing.Zipkin.HttpTransmitter"))
+            using (var stream = SerializationStreamManager.StreamManager.GetStream("Petabridge.Tracing.Zipkin.HttpTransmitter"))
             {
                 _serializer.Serialize(stream, spans);
                 var cts = new CancellationTokenSource(timeout);

--- a/src/Petabridge.Tracing.Zipkin/Reporting/Http/ZipkinHttpReportingOptions.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/Http/ZipkinHttpReportingOptions.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ZipkinHttpReportingOptions.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Reporting/Http/ZipkinHttpSpanReporter.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/Http/ZipkinHttpSpanReporter.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ZipkinHttpSpanReporter.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Reporting/ISpanSerializer.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/ISpanSerializer.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ISpanSerializer.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Reporting/JsonSpanSerializer.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/JsonSpanSerializer.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="JsonSpanSerializer.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/KafkaReportingActor.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/KafkaReportingActor.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using Akka.Actor;
+using Akka.Event;
+using Confluent.Kafka;
+using Confluent.Kafka.Serialization;
+using Phobos.Actor.Common;
+
+namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
+{
+    /// <summary>
+    /// INTERNAL API
+    ///  Actor responsible for managing the batching of outbound <see cref="T:Petabridge.Tracing.Zipkin.Span" /> instances.
+    /// </summary>
+    internal sealed class KafkaReportingActor : ReceiveActor, INeverMonitor, INeverTrace
+    {
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+
+        private readonly ZipkinKafkaReportingOptions _options;
+        private ICancelable _batchTransimissionTimer;
+
+        private KafkaTransmitter _kafkaProducer;
+
+        public KafkaReportingActor(ZipkinKafkaReportingOptions options)
+        {
+            Contract.Assert(options.Serializer != null);
+            _options = options;
+            PendingMessages = new List<Span>(_options.MaximumBatchSize);
+
+            Batching();
+        }
+
+        private void Batching()
+        {
+            Receive<Span>(s =>
+            {
+                PendingMessages.Add(s);
+                if (BatchSizeReached)
+                    ExecuteDelivery();
+            });
+
+            Receive<DeliverBatch>(d =>
+            {
+                if (PendingMessages.Any())
+                    ExecuteDelivery();
+                else
+                    RescheduleBatchTransmission();
+            });
+
+            Receive<Message<Null, byte[]>>(msg =>
+            {
+                if (msg.Error.HasError && _log.IsErrorEnabled)
+                {
+                    _log.Error("Error [{0}][{1}] occurred while uploading spans [{3} bytes] to Kafka endpoints [{2}] for topic [{4}]", msg.Error.Code, msg.Error.Reason,
+                        string.Join(",", _options.BootstrapServers), msg.Value.Length, msg.Topic);
+                }
+                else if(_log.IsDebugEnabled)
+                {
+                    _log.Debug("Successfully posted spans [{0} bytes] to Kafka for topic [{1}]", msg.Value.Length, msg.Topic);
+                }
+            });
+
+            // Indicates that one of our HTTP requests timed out
+            Receive<Status.Failure>(f =>
+            {
+                if (_log.IsErrorEnabled)
+                    _log.Error(f.Cause, "Error occurred while uploading Spans to Kafka endpoints [{0}]",
+                        string.Join(",",_options.BootstrapServers));
+            });
+        }
+
+        private void ExecuteDelivery()
+        {
+            _kafkaProducer.TransmitSpans(PendingMessages).PipeTo(Self);
+
+            PendingMessages.Clear();
+            RescheduleBatchTransmission();
+        }
+
+        private void RescheduleBatchTransmission()
+        {
+            _batchTransimissionTimer?.Cancel(false);
+            _batchTransimissionTimer =
+                Context.System.Scheduler.ScheduleTellOnceCancelable(_options.MaxBatchInterval, Self,
+                    DeliverBatch.Instance, Self);
+        }
+
+        protected override void PreStart()
+        {
+            RescheduleBatchTransmission();
+            _kafkaProducer = new KafkaTransmitter(_options.TopicName, 
+                new Producer<Null, byte[]>(_options.ToDriverConfig(), 
+                new NullSerializer(), new ByteArraySerializer()), _options.Serializer);
+
+            if (_options.DebugLogging)
+            {
+                _log.Debug("Connected to Kafka at [{0}] on topic [{1}] for Zipkin", string.Join(",", _options.BootstrapServers), _options.TopicName);
+            }
+        }
+
+        protected override void PostStop()
+        {
+            _batchTransimissionTimer?.Cancel();
+            _kafkaProducer?.Dispose();
+        }
+
+        public List<Span> PendingMessages { get; }
+
+        public bool BatchSizeReached => PendingMessages.Count >= _options.MaximumBatchSize;
+
+        /// <summary>
+        ///     INTERNAL API.
+        ///     Signal
+        /// </summary>
+        private sealed class DeliverBatch
+        {
+            public static readonly DeliverBatch Instance = new DeliverBatch();
+
+            private DeliverBatch()
+            {
+            }
+        }
+    }
+}

--- a/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/KafkaReportingActor.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/KafkaReportingActor.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="KafkaReportingActor.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
@@ -11,8 +16,8 @@ using Phobos.Actor.Common;
 namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
 {
     /// <summary>
-    /// INTERNAL API
-    ///  Actor responsible for managing the batching of outbound <see cref="T:Petabridge.Tracing.Zipkin.Span" /> instances.
+    ///     INTERNAL API
+    ///     Actor responsible for managing the batching of outbound <see cref="T:Petabridge.Tracing.Zipkin.Span" /> instances.
     /// </summary>
     internal sealed class KafkaReportingActor : ReceiveActor, INeverMonitor, INeverTrace
     {
@@ -31,6 +36,10 @@ namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
 
             Batching();
         }
+
+        public List<Span> PendingMessages { get; }
+
+        public bool BatchSizeReached => PendingMessages.Count >= _options.MaximumBatchSize;
 
         private void Batching()
         {
@@ -52,14 +61,13 @@ namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
             Receive<Message<Null, byte[]>>(msg =>
             {
                 if (msg.Error.HasError && _log.IsErrorEnabled)
-                {
-                    _log.Error("Error [{0}][{1}] occurred while uploading spans [{3} bytes] to Kafka endpoints [{2}] for topic [{4}]", msg.Error.Code, msg.Error.Reason,
+                    _log.Error(
+                        "Error [{0}][{1}] occurred while uploading spans [{3} bytes] to Kafka endpoints [{2}] for topic [{4}]",
+                        msg.Error.Code, msg.Error.Reason,
                         string.Join(",", _options.BootstrapServers), msg.Value.Length, msg.Topic);
-                }
-                else if(_log.IsDebugEnabled)
-                {
-                    _log.Debug("Successfully posted spans [{0} bytes] to Kafka for topic [{1}]", msg.Value.Length, msg.Topic);
-                }
+                else if (_log.IsDebugEnabled)
+                    _log.Debug("Successfully posted spans [{0} bytes] to Kafka for topic [{1}]", msg.Value.Length,
+                        msg.Topic);
             });
 
             // Indicates that one of our HTTP requests timed out
@@ -67,7 +75,7 @@ namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
             {
                 if (_log.IsErrorEnabled)
                     _log.Error(f.Cause, "Error occurred while uploading Spans to Kafka endpoints [{0}]",
-                        string.Join(",",_options.BootstrapServers));
+                        string.Join(",", _options.BootstrapServers));
             });
         }
 
@@ -90,14 +98,13 @@ namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
         protected override void PreStart()
         {
             RescheduleBatchTransmission();
-            _kafkaProducer = new KafkaTransmitter(_options.TopicName, 
-                new Producer<Null, byte[]>(_options.ToDriverConfig(), 
-                new NullSerializer(), new ByteArraySerializer()), _options.Serializer);
+            _kafkaProducer = new KafkaTransmitter(_options.TopicName,
+                new Producer<Null, byte[]>(_options.ToDriverConfig(),
+                    new NullSerializer(), new ByteArraySerializer()), _options.Serializer);
 
             if (_options.DebugLogging)
-            {
-                _log.Debug("Connected to Kafka at [{0}] on topic [{1}] for Zipkin", string.Join(",", _options.BootstrapServers), _options.TopicName);
-            }
+                _log.Debug("Connected to Kafka at [{0}] on topic [{1}] for Zipkin",
+                    string.Join(",", _options.BootstrapServers), _options.TopicName);
         }
 
         protected override void PostStop()
@@ -105,10 +112,6 @@ namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
             _batchTransimissionTimer?.Cancel();
             _kafkaProducer?.Dispose();
         }
-
-        public List<Span> PendingMessages { get; }
-
-        public bool BatchSizeReached => PendingMessages.Count >= _options.MaximumBatchSize;
 
         /// <summary>
         ///     INTERNAL API.

--- a/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/KafkaTransmitter.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/KafkaTransmitter.cs
@@ -1,19 +1,24 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="KafkaTransmitter.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Confluent.Kafka;
 
 namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
 {
     /// <summary>
-    /// INTERNAL API. Used to carry out serialization and transmission to Kafka.
+    ///     INTERNAL API. Used to carry out serialization and transmission to Kafka.
     /// </summary>
     public sealed class KafkaTransmitter : IDisposable
     {
-        private readonly string _topicName;
         private readonly Producer<Null, byte[]> _producer;
         private readonly ISpanSerializer _serializer;
+        private readonly string _topicName;
 
         public KafkaTransmitter(string topicName, Producer<Null, byte[]> producer, ISpanSerializer serializer)
         {
@@ -22,19 +27,20 @@ namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
             _topicName = topicName;
         }
 
+        public void Dispose()
+        {
+            _producer?.Dispose();
+        }
+
         public async Task<Message<Null, byte[]>> TransmitSpans(IEnumerable<Span> spans)
         {
-            using (var stream = SerializationStreamManager.StreamManager.GetStream("Petabridge.Tracing.Zipkin.KafkaTransmitter"))
+            using (var stream =
+                SerializationStreamManager.StreamManager.GetStream("Petabridge.Tracing.Zipkin.KafkaTransmitter"))
             {
                 _serializer.Serialize(stream, spans);
                 var outboundBytes = stream.ToArray();
                 return await _producer.ProduceAsync(_topicName, null, outboundBytes).ConfigureAwait(false);
             }
-        }
-
-        public void Dispose()
-        {
-            _producer?.Dispose();
         }
     }
 }

--- a/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/KafkaTransmitter.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/KafkaTransmitter.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+
+namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
+{
+    /// <summary>
+    /// INTERNAL API. Used to carry out serialization and transmission to Kafka.
+    /// </summary>
+    public sealed class KafkaTransmitter : IDisposable
+    {
+        private readonly string _topicName;
+        private readonly Producer<Null, byte[]> _producer;
+        private readonly ISpanSerializer _serializer;
+
+        public KafkaTransmitter(string topicName, Producer<Null, byte[]> producer, ISpanSerializer serializer)
+        {
+            _producer = producer;
+            _serializer = serializer;
+            _topicName = topicName;
+        }
+
+        public async Task<Message<Null, byte[]>> TransmitSpans(IEnumerable<Span> spans)
+        {
+            using (var stream = SerializationStreamManager.StreamManager.GetStream("Petabridge.Tracing.Zipkin.KafkaTransmitter"))
+            {
+                _serializer.Serialize(stream, spans);
+                var outboundBytes = stream.ToArray();
+                return await _producer.ProduceAsync(_topicName, null, outboundBytes).ConfigureAwait(false);
+            }
+        }
+
+        public void Dispose()
+        {
+            _producer?.Dispose();
+        }
+    }
+}

--- a/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/ZipkinKafkaReportingOptions.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/ZipkinKafkaReportingOptions.cs
@@ -1,19 +1,32 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="ZipkinKafkaReportingOptions.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
 {
     /// <summary>
-    /// All of the options used to configure <see cref="Span"/> reporting via Kafka.
+    ///     All of the options used to configure <see cref="Span" /> reporting via Kafka.
     /// </summary>
     public sealed class ZipkinKafkaReportingOptions
     {
         public const int DefaultBatchSize = 30;
+
+        /// <summary>
+        ///     The default topic name used by Zipkin, according to
+        ///     https://github.com/openzipkin/zipkin/blob/master/zipkin-autoconfigure/collector-kafka/README.md
+        /// </summary>
+        public const string DefaultKafkaTopicName = "zipkin";
+
         public static readonly TimeSpan DefaultReportingInterval = TimeSpan.FromMilliseconds(100);
 
-        public ZipkinKafkaReportingOptions(IReadOnlyList<string> bootstrapServers, string topicName = DefaultKafkaTopicName,
-            int maximumBatchSize = DefaultBatchSize, TimeSpan? maxBatchInterval = null, 
+        public ZipkinKafkaReportingOptions(IReadOnlyList<string> bootstrapServers,
+            string topicName = DefaultKafkaTopicName,
+            int maximumBatchSize = DefaultBatchSize, TimeSpan? maxBatchInterval = null,
             bool debugLogging = false, bool errorLogging = true)
         {
             TopicName = topicName;
@@ -26,21 +39,16 @@ namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
         }
 
         /// <summary>
-        /// The default topic name used by Zipkin, according to https://github.com/openzipkin/zipkin/blob/master/zipkin-autoconfigure/collector-kafka/README.md
-        /// </summary>
-        public const string DefaultKafkaTopicName = "zipkin";
-
-        /// <summary>
-        /// The name of the Kafka topic that will be consumed by Zipkin
-        /// for span reporting purposes.
+        ///     The name of the Kafka topic that will be consumed by Zipkin
+        ///     for span reporting purposes.
         /// </summary>
         /// <remarks>
-        /// Defaults to "zipkin".
+        ///     Defaults to "zipkin".
         /// </remarks>
         public string TopicName { get; }
 
         /// <summary>
-        /// The set of servers we will use to initially contact Kafka
+        ///     The set of servers we will use to initially contact Kafka
         /// </summary>
         public IReadOnlyList<string> BootstrapServers { get; }
 
@@ -65,21 +73,21 @@ namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
         public bool ErrorLogging { get; }
 
         /// <summary>
-        /// The serializer used for encoding <see cref="Span"/> instances on the wire.
-        /// Defaults to <see cref="JsonSpanSerializer"/>
+        ///     The serializer used for encoding <see cref="Span" /> instances on the wire.
+        ///     Defaults to <see cref="JsonSpanSerializer" />
         /// </summary>
         public ISpanSerializer Serializer { get; set; }
 
         /// <summary>
-        /// Creates a configuration object in the style expected by the Confluent.Kafka driver.
+        ///     Creates a configuration object in the style expected by the Confluent.Kafka driver.
         /// </summary>
         /// <returns>A new dictionary instance each time.</returns>
         public IReadOnlyDictionary<string, object> ToDriverConfig()
         {
             return new Dictionary<string, object>
             {
-                { "bootstrap.servers", string.Join(",", BootstrapServers) },
-                { "request.required.acks", "0" } // don't wait for broker to send ACKs back (it's just trace data)
+                {"bootstrap.servers", string.Join(",", BootstrapServers)},
+                {"request.required.acks", "0"} // don't wait for broker to send ACKs back (it's just trace data)
             };
         }
     }

--- a/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/ZipkinKafkaReportingOptions.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/ZipkinKafkaReportingOptions.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
+{
+    /// <summary>
+    /// All of the options used to configure <see cref="Span"/> reporting via Kafka.
+    /// </summary>
+    public sealed class ZipkinKafkaReportingOptions
+    {
+        public const int DefaultBatchSize = 30;
+        public static readonly TimeSpan DefaultReportingInterval = TimeSpan.FromMilliseconds(100);
+
+        public ZipkinKafkaReportingOptions(IReadOnlyList<string> bootstrapServers, string topicName = DefaultKafkaTopicName,
+            int maximumBatchSize = DefaultBatchSize, TimeSpan? maxBatchInterval = null, 
+            bool debugLogging = false, bool errorLogging = true)
+        {
+            TopicName = topicName;
+            BootstrapServers = bootstrapServers;
+            MaximumBatchSize = maximumBatchSize;
+            MaxBatchInterval = maxBatchInterval ?? DefaultReportingInterval;
+            DebugLogging = debugLogging;
+            ErrorLogging = errorLogging;
+            Serializer = new JsonSpanSerializer();
+        }
+
+        /// <summary>
+        /// The default topic name used by Zipkin, according to https://github.com/openzipkin/zipkin/blob/master/zipkin-autoconfigure/collector-kafka/README.md
+        /// </summary>
+        public const string DefaultKafkaTopicName = "zipkin";
+
+        /// <summary>
+        /// The name of the Kafka topic that will be consumed by Zipkin
+        /// for span reporting purposes.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to "zipkin".
+        /// </remarks>
+        public string TopicName { get; }
+
+        /// <summary>
+        /// The set of servers we will use to initially contact Kafka
+        /// </summary>
+        public IReadOnlyList<string> BootstrapServers { get; }
+
+        /// <summary>
+        ///     The maximum number of <see cref="Span" /> instances allowed in a single batch transmission.
+        /// </summary>
+        public int MaximumBatchSize { get; }
+
+        /// <summary>
+        ///     The maxium allowed time interval between batches.
+        /// </summary>
+        public TimeSpan MaxBatchInterval { get; }
+
+        /// <summary>
+        ///     Enables debug logging via the Akka.NET logging channels
+        /// </summary>
+        public bool DebugLogging { get; }
+
+        /// <summary>
+        ///     Enables error logging via the Akka.NET logging channels. Defaults to <c>true</c>.
+        /// </summary>
+        public bool ErrorLogging { get; }
+
+        /// <summary>
+        /// The serializer used for encoding <see cref="Span"/> instances on the wire.
+        /// Defaults to <see cref="JsonSpanSerializer"/>
+        /// </summary>
+        public ISpanSerializer Serializer { get; set; }
+
+        /// <summary>
+        /// Creates a configuration object in the style expected by the Confluent.Kafka driver.
+        /// </summary>
+        /// <returns>A new dictionary instance each time.</returns>
+        public IReadOnlyDictionary<string, object> ToDriverConfig()
+        {
+            return new Dictionary<string, object>
+            {
+                { "bootstrap.servers", string.Join(",", BootstrapServers) },
+                { "request.required.acks", "0" } // don't wait for broker to send ACKs back (it's just trace data)
+            };
+        }
+    }
+}

--- a/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/ZipkinKafkaSpanReporter.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/ZipkinKafkaSpanReporter.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Util.Internal;
+using Confluent.Kafka;
+
+namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
+{
+    /// <summary>
+    /// Kafka <see cref="Producer"/> span reporter implementation.
+    /// </summary>
+    public sealed class ZipkinKafkaSpanReporter : ISpanReporter
+    {
+        private static readonly AtomicCounter NameCounter = new AtomicCounter(0);
+
+        private static readonly Config NormalHocon = ConfigurationFactory.Empty;
+        private static readonly Config DebugHocon = ConfigurationFactory.ParseString(@"akka.loglevel = DEBUG");
+        private readonly ActorSystem _ownedActorSystem; // if we own the ActorSystem, we have to kill it.
+        private readonly IActorRef _reporterActorRef;
+
+        internal ZipkinKafkaSpanReporter(IActorRef reporterActorRef, ActorSystem ownedActorSystem = null)
+        {
+            _reporterActorRef = reporterActorRef;
+            _ownedActorSystem = ownedActorSystem;
+        }
+
+        public void Dispose()
+        {
+            // give it a chance to cleanup
+            _reporterActorRef.GracefulStop(TimeSpan.FromSeconds(5)).Wait();
+
+            // then optionally terminate ActorSystem
+            _ownedActorSystem?.Terminate().Wait();
+        }
+
+        public void Report(Span span)
+        {
+            _reporterActorRef.Tell(span);
+        }
+
+        /// <summary>
+        ///     Performs all of the setup and initialization needed to get the Zipkin Kafka reporting engine up and running.
+        /// </summary>
+        /// <param name="kafkaBrokerEndpoint">A single kafka broker endpoint.</param>
+        /// <param name="actorSystem">
+        ///     Optional. If using Akka.NET, you can hook your own <see cref="ActorSystem" /> into our
+        ///     reporting engine.
+        /// </param>
+        /// <returns></returns>
+        public static ZipkinKafkaSpanReporter Create(string kafkaBrokerEndpoint,
+            ActorSystem actorSystem = null)
+        {
+            return Create(new []{ kafkaBrokerEndpoint }, actorSystem);
+        }
+
+        /// <summary>
+        ///     Performs all of the setup and initialization needed to get the Zipkin Kafka reporting engine up and running.
+        /// </summary>
+        /// <param name="kafkaBrokerEndpoints">A list of kafka broker endpoints.</param>
+        /// <param name="actorSystem">
+        ///     Optional. If using Akka.NET, you can hook your own <see cref="ActorSystem" /> into our
+        ///     reporting engine.
+        /// </param>
+        /// <returns></returns>
+        public static ZipkinKafkaSpanReporter Create(IReadOnlyList<string> kafkaBrokerEndpoints,
+            ActorSystem actorSystem = null)
+        {
+            return Create(new ZipkinKafkaReportingOptions(kafkaBrokerEndpoints), actorSystem);
+        }
+
+        /// <summary>
+        ///     Performs all of the setup and initialization needed to get the Zipkin Kafka reporting engine up and running.
+        /// </summary>
+        /// <param name="options">The set of options for configuring timeouts and batch sizes.</param>
+        /// <param name="actorSystem">
+        ///     Optional. If using Akka.NET, you can hook your own <see cref="ActorSystem" /> into our
+        ///     reporting engine.
+        /// </param>
+        /// <returns></returns>
+        public static ZipkinKafkaSpanReporter Create(ZipkinKafkaReportingOptions options, ActorSystem actorSystem = null)
+        {
+            // force this component to explode if the end-user screwed up the URI somehow.
+            var weOwnActorSystem = false;
+
+            if (actorSystem == null) // create our own ActorSystem if it doesn't already exist.
+            {
+                weOwnActorSystem = true;
+                actorSystem = ActorSystem.Create("pbzipkin",
+                    options.DebugLogging ? DebugHocon : NormalHocon);
+            }
+
+            // spawn as a System actor, so in the event of being in a non-owned system our traces get shut down
+            // only after all of the user-defined actors have terminated.
+            var zipkinActor = actorSystem.AsInstanceOf<ExtendedActorSystem>().SystemActorOf(
+                Props.Create(() => new KafkaReportingActor(options)), $"zipkin-tracing-kafka-{NameCounter.GetAndIncrement()}");
+
+            return new ZipkinKafkaSpanReporter(zipkinActor, weOwnActorSystem ? actorSystem : null);
+        }
+    }
+}

--- a/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/ZipkinKafkaSpanReporter.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/ZipkinKafkaSpanReporter.cs
@@ -1,15 +1,19 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="ZipkinKafkaSpanReporter.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
-using System.Text;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Util.Internal;
-using Confluent.Kafka;
 
 namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
 {
     /// <summary>
-    /// Kafka <see cref="Producer"/> span reporter implementation.
+    ///     Kafka <see cref="Producer" /> span reporter implementation.
     /// </summary>
     public sealed class ZipkinKafkaSpanReporter : ISpanReporter
     {
@@ -52,7 +56,7 @@ namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
         public static ZipkinKafkaSpanReporter Create(string kafkaBrokerEndpoint,
             ActorSystem actorSystem = null)
         {
-            return Create(new []{ kafkaBrokerEndpoint }, actorSystem);
+            return Create(new[] {kafkaBrokerEndpoint}, actorSystem);
         }
 
         /// <summary>
@@ -79,7 +83,8 @@ namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
         ///     reporting engine.
         /// </param>
         /// <returns></returns>
-        public static ZipkinKafkaSpanReporter Create(ZipkinKafkaReportingOptions options, ActorSystem actorSystem = null)
+        public static ZipkinKafkaSpanReporter Create(ZipkinKafkaReportingOptions options,
+            ActorSystem actorSystem = null)
         {
             // force this component to explode if the end-user screwed up the URI somehow.
             var weOwnActorSystem = false;
@@ -94,7 +99,8 @@ namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
             // spawn as a System actor, so in the event of being in a non-owned system our traces get shut down
             // only after all of the user-defined actors have terminated.
             var zipkinActor = actorSystem.AsInstanceOf<ExtendedActorSystem>().SystemActorOf(
-                Props.Create(() => new KafkaReportingActor(options)), $"zipkin-tracing-kafka-{NameCounter.GetAndIncrement()}");
+                Props.Create(() => new KafkaReportingActor(options)),
+                $"zipkin-tracing-kafka-{NameCounter.GetAndIncrement()}");
 
             return new ZipkinKafkaSpanReporter(zipkinActor, weOwnActorSystem ? actorSystem : null);
         }

--- a/src/Petabridge.Tracing.Zipkin/Reporting/NoOp/NoOpReporter.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/NoOp/NoOpReporter.cs
@@ -1,0 +1,24 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="NoOpReporter.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Petabridge.Tracing.Zipkin.Reporting.NoOp
+{
+    /// <summary>
+    ///     INTERNAL API.
+    ///     Reporter that doesn't actually report spans. Used for unit testing.
+    /// </summary>
+    public sealed class NoOpReporter : ISpanReporter
+    {
+        public void Dispose()
+        {
+        }
+
+        public void Report(Span span)
+        {
+            // no-op
+        }
+    }
+}

--- a/src/Petabridge.Tracing.Zipkin/Reporting/SerializationStreamManager.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/SerializationStreamManager.cs
@@ -1,12 +1,18 @@
-﻿using Microsoft.IO;
+﻿// -----------------------------------------------------------------------
+// <copyright file="SerializationStreamManager.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Microsoft.IO;
 
 namespace Petabridge.Tracing.Zipkin.Reporting
 {
     /// <summary>
-    /// INTERNAL API.
-    ///
-    /// Used to provide access to the <see cref="RecyclableMemoryStreamManager"/> across different <see cref="ISpanReporter"/>
-    /// implementations.
+    ///     INTERNAL API.
+    ///     Used to provide access to the <see cref="RecyclableMemoryStreamManager" /> across different
+    ///     <see cref="ISpanReporter" />
+    ///     implementations.
     /// </summary>
     internal static class SerializationStreamManager
     {

--- a/src/Petabridge.Tracing.Zipkin/Reporting/SerializationStreamManager.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/SerializationStreamManager.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.IO;
+
+namespace Petabridge.Tracing.Zipkin.Reporting
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Used to provide access to the <see cref="RecyclableMemoryStreamManager"/> across different <see cref="ISpanReporter"/>
+    /// implementations.
+    /// </summary>
+    internal static class SerializationStreamManager
+    {
+        /// <summary>
+        ///     Only need one of these globally, and it's thread-safe. The streams it accesses internally are inherently not safe.
+        /// </summary>
+        public static readonly RecyclableMemoryStreamManager StreamManager = new RecyclableMemoryStreamManager();
+    }
+}

--- a/src/Petabridge.Tracing.Zipkin/Sampling/ExternalSampling.cs
+++ b/src/Petabridge.Tracing.Zipkin/Sampling/ExternalSampling.cs
@@ -1,16 +1,26 @@
-﻿namespace Petabridge.Tracing.Zipkin.Sampling
+﻿// -----------------------------------------------------------------------
+// <copyright file="ExternalSampling.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Petabridge.Tracing.Zipkin.Sampling
 {
     /// <inheritdoc />
     /// <summary>
-    /// Used when sampling is running, but it's driven by an external engine
-    /// rather than anything internal to this Zipkin driver itself.
+    ///     Used when sampling is running, but it's driven by an external engine
+    ///     rather than anything internal to this Zipkin driver itself.
     /// </summary>
     public sealed class ExternalSampling : ITraceSampler
     {
         public static readonly ExternalSampling Instance = new ExternalSampling();
-        private ExternalSampling() { }
+
+        private ExternalSampling()
+        {
+        }
 
         public bool Sampling { get; } = true;
+
         public bool IncludeInSample(string operationName)
         {
             /*

--- a/src/Petabridge.Tracing.Zipkin/Sampling/NoSampler.cs
+++ b/src/Petabridge.Tracing.Zipkin/Sampling/NoSampler.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="NoSampler.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Sampling/ProbabilisticSampler.cs
+++ b/src/Petabridge.Tracing.Zipkin/Sampling/ProbabilisticSampler.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ProbabilisticSampler.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Span.cs
+++ b/src/Petabridge.Tracing.Zipkin/Span.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Span.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 
@@ -185,16 +185,6 @@ namespace Petabridge.Tracing.Zipkin
             return Log(timestamp, MergeFields(fields));
         }
 
-        public ISpan Log(IDictionary<string, object> fields)
-        {
-            return Log(_tracer.TimeProvider.Now, MergeFields(fields));
-        }
-
-        public ISpan Log(DateTimeOffset timestamp, IDictionary<string, object> fields)
-        {
-            return Log(timestamp, MergeFields(fields));
-        }
-
         public ISpan Log(string @event)
         {
             return Log(_tracer.TimeProvider.Now, @event);
@@ -240,6 +230,16 @@ namespace Petabridge.Tracing.Zipkin
         ///     For OpenTracing compatibility.
         /// </summary>
         public ISpanContext Context => TypedContext;
+
+        public ISpan Log(IDictionary<string, object> fields)
+        {
+            return Log(_tracer.TimeProvider.Now, MergeFields(fields));
+        }
+
+        public ISpan Log(DateTimeOffset timestamp, IDictionary<string, object> fields)
+        {
+            return Log(timestamp, MergeFields(fields));
+        }
 
         /// <summary>
         ///     Sets the <see cref="RemoteEndpoint" /> for this span.

--- a/src/Petabridge.Tracing.Zipkin/SpanBuilder.cs
+++ b/src/Petabridge.Tracing.Zipkin/SpanBuilder.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="SpanBuilder.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 
@@ -206,9 +206,11 @@ namespace Petabridge.Tracing.Zipkin
 
 
             return new Span(_tracer, _operationName,
-                new SpanContext(parentContext.IsEmpty() ? _tracer.IdProvider.NextTraceId() : parentContext.ZipkinTraceId,
+                new SpanContext(
+                    parentContext.IsEmpty() ? _tracer.IdProvider.NextTraceId() : parentContext.ZipkinTraceId,
                     _tracer.IdProvider.NextSpanId(),
-                    parentContext?.SpanId, _enableDebug, _tracer.Sampler.Sampling, _shared), _start.Value, _spanKind, tags:_initialTags);
+                    parentContext?.SpanId, _enableDebug, _tracer.Sampler.Sampling, _shared), _start.Value, _spanKind,
+                tags: _initialTags);
         }
 
         public IZipkinSpanBuilder WithSpanKind(SpanKind spanKind)

--- a/src/Petabridge.Tracing.Zipkin/SpanContext.cs
+++ b/src/Petabridge.Tracing.Zipkin/SpanContext.cs
@@ -14,6 +14,9 @@ namespace Petabridge.Tracing.Zipkin
     /// </summary>
     public sealed class SpanContext : IZipkinSpanContext
     {
+        [Obsolete("As of Petabridge.Tracing.Zipkin v0.3.0, we now support OpenTracing v0.12 and all drivers " +
+                  "are required to use strings as span and trace ids. Please use the string-based overload " +
+                  "of this constructor instead.")]
         public SpanContext(TraceId traceId, long spanId, string parentId = null, bool debug = false,
             bool sampled = false, bool shared = false) 
             : this(traceId, spanId.ToString("x16"), parentId, 
@@ -106,6 +109,12 @@ namespace Petabridge.Tracing.Zipkin
         public static bool operator !=(SpanContext left, SpanContext right)
         {
             return !Equals(left, right);
+        }
+
+        public override string ToString()
+        {
+            return $"(ZipkinSpanContext: TraceId={TraceId}, SpanId={SpanId}, ParentId={ParentId}," +
+                   $"Sampled={Sampled}, Debug={Debug}, Shared={Shared})";
         }
     }
 }

--- a/src/Petabridge.Tracing.Zipkin/SpanContext.cs
+++ b/src/Petabridge.Tracing.Zipkin/SpanContext.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="SpanContext.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 
@@ -18,8 +18,8 @@ namespace Petabridge.Tracing.Zipkin
                   "are required to use strings as span and trace ids. Please use the string-based overload " +
                   "of this constructor instead.")]
         public SpanContext(TraceId traceId, long spanId, string parentId = null, bool debug = false,
-            bool sampled = false, bool shared = false) 
-            : this(traceId, spanId.ToString("x16"), parentId, 
+            bool sampled = false, bool shared = false)
+            : this(traceId, spanId.ToString("x16"), parentId,
                 debug, sampled, shared)
         {
         }

--- a/src/Petabridge.Tracing.Zipkin/TraceId.cs
+++ b/src/Petabridge.Tracing.Zipkin/TraceId.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="TraceId.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Tracers/MockZipkinTracer.cs
+++ b/src/Petabridge.Tracing.Zipkin/Tracers/MockZipkinTracer.cs
@@ -61,7 +61,8 @@ namespace Petabridge.Tracing.Zipkin.Tracers
             if ((format == BuiltinFormats.TextMap || format == BuiltinFormats.HttpHeaders) &&
                 carrier is ITextMap textMap)
             {
-                _propagator.Inject((SpanContext) spanContext, textMap);
+                if(spanContext is SpanContext zipkinContext)
+                    _propagator.Inject(zipkinContext, textMap);
                 return;
             }
 

--- a/src/Petabridge.Tracing.Zipkin/Tracers/MockZipkinTracer.cs
+++ b/src/Petabridge.Tracing.Zipkin/Tracers/MockZipkinTracer.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="MockZipkinTracer.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 
@@ -61,7 +61,7 @@ namespace Petabridge.Tracing.Zipkin.Tracers
             if ((format == BuiltinFormats.TextMap || format == BuiltinFormats.HttpHeaders) &&
                 carrier is ITextMap textMap)
             {
-                if(spanContext is SpanContext zipkinContext)
+                if (spanContext is SpanContext zipkinContext)
                     _propagator.Inject(zipkinContext, textMap);
                 return;
             }

--- a/src/Petabridge.Tracing.Zipkin/Tracers/NoOp.cs
+++ b/src/Petabridge.Tracing.Zipkin/Tracers/NoOp.cs
@@ -1,11 +1,17 @@
-﻿using OpenTracing;
+﻿// -----------------------------------------------------------------------
+// <copyright file="NoOp.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using OpenTracing;
 using OpenTracing.Noop;
 
 namespace Petabridge.Tracing.Zipkin.Tracers
 {
     /// <summary>
-    /// Taps into the OpenTracing.NoOpTracer primitives,
-    /// which aren't publicly accessible right now as of OpenTracing v0.11
+    ///     Taps into the OpenTracing.NoOpTracer primitives,
+    ///     which aren't publicly accessible right now as of OpenTracing v0.11
     /// </summary>
     public static class NoOp
     {

--- a/src/Petabridge.Tracing.Zipkin/Tracers/NoOpZipkinSpan.cs
+++ b/src/Petabridge.Tracing.Zipkin/Tracers/NoOpZipkinSpan.cs
@@ -1,6 +1,11 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="NoOpZipkinSpan.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
-using System.Text;
 using OpenTracing;
 using OpenTracing.Tag;
 
@@ -69,16 +74,6 @@ namespace Petabridge.Tracing.Zipkin.Tracers
             return this;
         }
 
-        public ISpan Log(IDictionary<string, object> fields)
-        {
-            return this;
-        }
-
-        public ISpan Log(DateTimeOffset timestamp, IDictionary<string, object> fields)
-        {
-            return this;
-        }
-
         public ISpan Log(string @event)
         {
             return this;
@@ -118,5 +113,15 @@ namespace Petabridge.Tracing.Zipkin.Tracers
         public bool Shared => TypedContext.Shared;
         public bool Sampled => TypedContext.Sampled;
         public SpanKind? SpanKind => null;
+
+        public ISpan Log(IDictionary<string, object> fields)
+        {
+            return this;
+        }
+
+        public ISpan Log(DateTimeOffset timestamp, IDictionary<string, object> fields)
+        {
+            return this;
+        }
     }
 }

--- a/src/Petabridge.Tracing.Zipkin/Tracers/NoOpZipkinSpanContext.cs
+++ b/src/Petabridge.Tracing.Zipkin/Tracers/NoOpZipkinSpanContext.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="NoOpZipkinSpanContext.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Util/DateTimeOffsetTimeProvider.cs
+++ b/src/Petabridge.Tracing.Zipkin/Util/DateTimeOffsetTimeProvider.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="DateTimeOffsetTimeProvider.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Util/MicrosecondConversion.cs
+++ b/src/Petabridge.Tracing.Zipkin/Util/MicrosecondConversion.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="MicrosecondConversion.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Util/SpanExtensions.cs
+++ b/src/Petabridge.Tracing.Zipkin/Util/SpanExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="SpanExtensions.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 
@@ -21,17 +21,18 @@ namespace Petabridge.Tracing.Zipkin.Util
         /// <returns><c>true</c> if the span is empty, <c>false</c> otherwise.</returns>
         public static bool IsEmpty(this ISpanContext context)
         {
-            return context == null || NoOp.Span.Context.Equals(context) || Equals(NoOpZipkinSpanContext.Instance, context);
+            return context == null || NoOp.Span.Context.Equals(context) ||
+                   Equals(NoOpZipkinSpanContext.Instance, context);
         }
 
         /// <summary>
-        /// Determines if an <see cref="ISpanContext"/> is a valid <see cref="IZipkinSpanContext"/> or not.
+        ///     Determines if an <see cref="ISpanContext" /> is a valid <see cref="IZipkinSpanContext" /> or not.
         /// </summary>
         /// <param name="context">The span context.</param>
         /// <returns><c>true</c> if the span is valid, <c>false</c> otherwise.</returns>
         public static bool IsZipkinSpan(this ISpanContext context)
         {
-            return !IsEmpty(context) && (context is IZipkinSpanContext);
+            return !IsEmpty(context) && context is IZipkinSpanContext;
         }
     }
 }

--- a/src/Petabridge.Tracing.Zipkin/Util/SpanTextFormatters.cs
+++ b/src/Petabridge.Tracing.Zipkin/Util/SpanTextFormatters.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="SpanTextFormatters.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/Util/ThreadLocalRngSpanIdProvider.cs
+++ b/src/Petabridge.Tracing.Zipkin/Util/ThreadLocalRngSpanIdProvider.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ThreadLocalRngSpanIdProvider.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 
@@ -36,15 +36,15 @@ namespace Petabridge.Tracing.Zipkin.Util
             return new TraceId(NextSpanIdLong());
         }
 
+        public string NextSpanId()
+        {
+            return NextSpanIdLong().ToString("x16");
+        }
+
         public long NextSpanIdLong()
         {
             Rng.Value.NextBytes(Buffers.Value);
             return BitConverter.ToInt64(Buffers.Value, 0);
-        }
-
-        public string NextSpanId()
-        {
-            return NextSpanIdLong().ToString("x16");
         }
     }
 }

--- a/src/Petabridge.Tracing.Zipkin/Util/ThreadLocalRngSpanIdProvider.cs
+++ b/src/Petabridge.Tracing.Zipkin/Util/ThreadLocalRngSpanIdProvider.cs
@@ -32,14 +32,19 @@ namespace Petabridge.Tracing.Zipkin.Util
         public TraceId NextTraceId()
         {
             if (Use128Bit)
-                return new TraceId(NextSpanId(), NextSpanId());
-            return new TraceId(NextSpanId());
+                return new TraceId(NextSpanIdLong(), NextSpanIdLong());
+            return new TraceId(NextSpanIdLong());
         }
 
-        public long NextSpanId()
+        public long NextSpanIdLong()
         {
             Rng.Value.NextBytes(Buffers.Value);
             return BitConverter.ToInt64(Buffers.Value, 0);
+        }
+
+        public string NextSpanId()
+        {
+            return NextSpanIdLong().ToString("x16");
         }
     }
 }

--- a/src/Petabridge.Tracing.Zipkin/ZipkinTracer.cs
+++ b/src/Petabridge.Tracing.Zipkin/ZipkinTracer.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ZipkinTracer.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Petabridge.Tracing.Zipkin/ZipkinTracer.cs
+++ b/src/Petabridge.Tracing.Zipkin/ZipkinTracer.cs
@@ -81,7 +81,8 @@ namespace Petabridge.Tracing.Zipkin
             if ((format == BuiltinFormats.TextMap || format == BuiltinFormats.HttpHeaders) &&
                 carrier is ITextMap textMap)
             {
-                _propagator.Inject((SpanContext) spanContext, textMap);
+                if (spanContext is SpanContext zipkinContext)
+                    _propagator.Inject(zipkinContext, textMap);
                 return;
             }
 

--- a/src/Petabridge.Tracing.Zipkin/ZipkinTracerOptions.cs
+++ b/src/Petabridge.Tracing.Zipkin/ZipkinTracerOptions.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ZipkinTracerOptions.cs" company="Petabridge, LLC">
-//      Copyright (C) 2018 - 2018 Petabridge, LLC <https://petabridge.com>
+//      Copyright (C) 2015 - 2018 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/common.props
+++ b/src/common.props
@@ -2,9 +2,8 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2018 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.3.1</VersionPrefix>
-    <PackageReleaseNotes>[Added `ExternalSampling`](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/46) - which allows the driver to accept sampling decisions made outside of the driver itself.
-[Added NBench performance specifications](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/47) and [Dockerized integration tests](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/41).</PackageReleaseNotes>
+    <VersionPrefix>0.3.2</VersionPrefix>
+    <PackageReleaseNotes>[Implemented some missing OpenTracing v0.1.2 APIs](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/51).</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://github.com/petabridge/Petabridge.Tracing.Zipkin

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,20 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2018 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.3.2</VersionPrefix>
-    <PackageReleaseNotes>[Implemented some missing OpenTracing v0.1.2 APIs](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/51).</PackageReleaseNotes>
+    <VersionPrefix>0.4.0</VersionPrefix>
+    <PackageReleaseNotes>Added support for Zipkin's built-in Kafka span reporting capabilities, for users who are already considering operating at that kind of large scale.
+You can access the Kafka reporter via the following syntax:
+```
+var tracer = new ZipkinTracer(new ZipkinTracerOptions(new Endpoint("AaronsAppKafka"),
+ZipkinKafkaSpanReporter.Create(new ZipkinKafkaReportingOptions(new[] {"localhost:19092"},
+debugLogging: true))));
+```
+The `ZipkinKafkaSpanReporter.Create` method will give you the ability to specify the Kafka endpoint, topic, and batching settings used by Petabridge.Tracing.Zipkin for reporting spans back to Zipkin via a Kafka topic. Normally, however, all you'll need to specify is just a set of endpoints for Kafka brokers - both Zipkin and the Petabridge.Tracing.Zipkin client use the "zipkin" topic by default.
+Other Changes**
+Petabridge.Tracing.Zipkin also introduces the following changes:
+[BugFix: calling ITracer.Inject with a NoOp span context causes cast exception](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/56)
+[BugFix: B3Propagator.Extract always returns a span context even when one isn't present](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/55)
+[Upgraded to use Akka.NET v1.3.9](https://github.com/akkadotnet/akka.net/releases/tag/v1.3.9)</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://github.com/petabridge/Petabridge.Tracing.Zipkin


### PR DESCRIPTION
#### 0.4.0 August 28 2018 ###
Added support for Zipkin's built-in Kafka span reporting capabilities, for users who are already considering operating at that kind of large scale.

You can access the Kafka reporter via the following syntax:

```
var tracer = new ZipkinTracer(new ZipkinTracerOptions(new Endpoint("AaronsAppKafka"),
                ZipkinKafkaSpanReporter.Create(new ZipkinKafkaReportingOptions(new[] {"localhost:19092"},
                    debugLogging: true))));
```

The `ZipkinKafkaSpanReporter.Create` method will give you the ability to specify the Kafka endpoint, topic, and batching settings used by Petabridge.Tracing.Zipkin for reporting spans back to Zipkin via a Kafka topic. Normally, however, all you'll need to specify is just a set of endpoints for Kafka brokers - both Zipkin and the Petabridge.Tracing.Zipkin client use the "zipkin" topic by default.

**Other Changes**
Petabridge.Tracing.Zipkin also introduces fixes for the following bugs:

* [BugFix: calling ITracer.Inject with a NoOp span context causes cast exception](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/56)
* [BugFix: B3Propagator.Extract always returns a span context even when one isn't present](https://github.com/petabridge/Petabridge.Tracing.Zipkin/issues/55)
* [Upgraded to use Akka.NET v1.3.9](https://github.com/akkadotnet/akka.net/releases/tag/v1.3.9)