### PR TITLE
Using AsyncLocalScopeManager as a default tracer's ScopeManager 

### DIFF
--- a/src/Petabridge.Tracing.Zipkin.Tests/TracerSpec.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/TracerSpec.cs
@@ -1,0 +1,23 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Petabridge.Tracing.Zipkin.Tests
+{
+    public class TracerSpec
+    {
+        [Fact]
+        public void Should_have_active_span_when_scope_is_used()
+        {
+            var url = "http://localhost:9411";
+            using (var tracer = new ZipkinTracer(new ZipkinTracerOptions(url, "ZipkinTest", debug: true)))
+            {
+                using (var scope = tracer.BuildSpan("ShouldSendSpans").StartActive(finishSpanOnDispose: true))
+                {
+                    tracer.ActiveSpan.Should().NotBeNull();
+                }
+
+                tracer.ActiveSpan.Should().BeNull();
+            }
+        }
+    }
+}

--- a/src/Petabridge.Tracing.Zipkin/ZipkinTracer.cs
+++ b/src/Petabridge.Tracing.Zipkin/ZipkinTracer.cs
@@ -7,6 +7,7 @@
 using System;
 using OpenTracing;
 using OpenTracing.Propagation;
+using OpenTracing.Util;
 using Petabridge.Tracing.Zipkin.Exceptions;
 using Petabridge.Tracing.Zipkin.Propagation;
 using Petabridge.Tracing.Zipkin.Sampling;
@@ -29,7 +30,7 @@ namespace Petabridge.Tracing.Zipkin
             _reporter = options.Reporter;
             LocalEndpoint = options.LocalEndpoint;
             TimeProvider = options.TimeProvider ?? new DateTimeOffsetTimeProvider();
-            ScopeManager = options.ScopeManager ?? NoOp.ScopeManager;
+            ScopeManager = options.ScopeManager ?? new AsyncLocalScopeManager();
             IdProvider = options.IdProvider ?? ThreadLocalRngSpanIdProvider.TraceId128BitProvider;
             Sampler = options.Sampler ?? NoSampler.Instance;
             Options = options;


### PR DESCRIPTION
Close #95