### PR TITLE
added v0.5.3 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,3 @@
-#### 0.5.2 November 11 2019 ###
-* Upgraded all dependencies.
+#### 0.5.3 January 29 2020 ###
+* Upgraded to latest Akka.NET, Kafka drivers.
+* [OpenTracing: Using AsyncLocalScopeManager as a default tracer's ScopeManager](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/131)

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2018 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.5.2</VersionPrefix>
-    <PackageReleaseNotes>Upgraded all dependencies.</PackageReleaseNotes>
+    <VersionPrefix>0.5.3</VersionPrefix>
+    <PackageReleaseNotes>Upgraded to latest Akka.NET, Kafka drivers.
+[OpenTracing: Using AsyncLocalScopeManager as a default tracer's ScopeManager](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/131)</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://github.com/petabridge/Petabridge.Tracing.Zipkin


### PR DESCRIPTION
#### 0.5.3 January 29 2020 ###
* Upgraded to latest Akka.NET, Kafka drivers.
* [OpenTracing: Using AsyncLocalScopeManager as a default tracer's ScopeManager](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/131)