### PR TITLE
v0.5.3 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,3 @@
-#### 0.5.2 November 11 2019 ###
-* Upgraded all dependencies.
+#### 0.5.3 January 29 2020 ###
+* Upgraded to latest Akka.NET, Kafka drivers.
+* [OpenTracing: Using AsyncLocalScopeManager as a default tracer's ScopeManager](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/131)

--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -9,6 +9,7 @@ trigger:
   branches:
     include:
       - refs/tags/*
+      
 pr: none
 
 variables:

--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -26,7 +26,7 @@ steps:
   displayName: 'FAKE Build'
   inputs:
     filename: build.cmd
-    arguments: 'All SignClientUser=$(signingUsername) SignClientSecret=$(signingPassword) nugetpublishurl=https://api.nuget.org/v3/index.json nugetkey=$(nugetKey)'
+    arguments: 'nuget SignClientUser=$(signingUsername) SignClientSecret=$(signingPassword) nugetpublishurl=https://api.nuget.org/v3/index.json nugetkey=$(nugetKey)'
 
 - task: GitHubRelease@0
   displayName: 'GitHub release (create)'

--- a/build.fsx
+++ b/build.fsx
@@ -23,14 +23,21 @@ let solutionFile = FindFirstMatchingFile "*.sln" __SOURCE_DIRECTORY__  // dynami
 let buildNumber = environVarOrDefault "BUILD_NUMBER" "0"
 let hasTeamCity = (not (buildNumber = "0")) // check if we have the TeamCity environment variable for build # set
 let preReleaseVersionSuffix = "beta" + (if (not (buildNumber = "0")) then (buildNumber) else DateTime.UtcNow.Ticks.ToString())
+
+let releaseNotes =
+    File.ReadLines (__SOURCE_DIRECTORY__ @@ "RELEASE_NOTES.md")
+    |> ReleaseNotesHelper.parseReleaseNotes
+
+let versionFromReleaseNotes =
+    match releaseNotes.SemVer.PreRelease with
+    | Some r -> r.Origin
+    | None -> ""
+
 let versionSuffix = 
     match (getBuildParam "nugetprerelease") with
     | "dev" -> preReleaseVersionSuffix
-    | _ -> ""
-
-let releaseNotes =
-    File.ReadLines "./RELEASE_NOTES.md"
-    |> ReleaseNotesHelper.parseReleaseNotes
+    | "" -> versionFromReleaseNotes
+    | str -> str
 
 // Directories
 let toolsDir = __SOURCE_DIRECTORY__ @@ "tools"

--- a/src/Petabridge.Tracing.Zipkin.Integration.Tests/Petabridge.Tracing.Zipkin.Integration.Tests.csproj
+++ b/src/Petabridge.Tracing.Zipkin.Integration.Tests/Petabridge.Tracing.Zipkin.Integration.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
     <PackageReference Include="Docker.DotNet" Version="3.125.2" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />

--- a/src/Petabridge.Tracing.Zipkin.Tests/Petabridge.Tracing.Zipkin.Tests.csproj
+++ b/src/Petabridge.Tracing.Zipkin.Tests/Petabridge.Tracing.Zipkin.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.0" />
     <PackageReference Include="FsCheck.Xunit" Version="2.14.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />

--- a/src/Petabridge.Tracing.Zipkin.Tests/TracerSpec.cs
+++ b/src/Petabridge.Tracing.Zipkin.Tests/TracerSpec.cs
@@ -1,0 +1,23 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Petabridge.Tracing.Zipkin.Tests
+{
+    public class TracerSpec
+    {
+        [Fact]
+        public void Should_have_active_span_when_scope_is_used()
+        {
+            var url = "http://localhost:9411";
+            using (var tracer = new ZipkinTracer(new ZipkinTracerOptions(url, "ZipkinTest", debug: true)))
+            {
+                using (var scope = tracer.BuildSpan("ShouldSendSpans").StartActive(finishSpanOnDispose: true))
+                {
+                    tracer.ActiveSpan.Should().NotBeNull();
+                }
+
+                tracer.ActiveSpan.Should().BeNull();
+            }
+        }
+    }
+}

--- a/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
+++ b/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OpenTracing" Version="0.12.1" />
-    <PackageReference Include="Phobos.Actor.Common" Version="1.0.0" />
+    <PackageReference Include="Phobos.Actor.Common" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
+++ b/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OpenTracing" Version="0.12.1" />
-    <PackageReference Include="Phobos.Actor.Common" Version="1.1.0" />
+    <PackageReference Include="Phobos.Actor.Common" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
+++ b/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Akka" Version="$(AkkaVersion)" />
-    <PackageReference Include="Confluent.Kafka" Version="0.11.6" />
+    <PackageReference Include="Confluent.Kafka" Version="1.2.2" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OpenTracing" Version="0.12.1" />

--- a/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
+++ b/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Akka" Version="$(AkkaVersion)" />
     <PackageReference Include="Confluent.Kafka" Version="1.2.2" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.0" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OpenTracing" Version="0.12.1" />
     <PackageReference Include="Phobos.Actor.Common" Version="1.1.1" />

--- a/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
+++ b/src/Petabridge.Tracing.Zipkin/Petabridge.Tracing.Zipkin.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Akka" Version="$(AkkaVersion)" />
-    <PackageReference Include="Confluent.Kafka" Version="1.2.2" />
+    <PackageReference Include="Confluent.Kafka" Version="1.3.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OpenTracing" Version="0.12.1" />

--- a/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/ZipkinKafkaReportingOptions.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/ZipkinKafkaReportingOptions.cs
@@ -87,9 +87,9 @@ namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
         ///     Creates a configuration object in the style expected by the Confluent.Kafka driver.
         /// </summary>
         /// <returns>A new dictionary instance each time.</returns>
-        public IReadOnlyDictionary<string, object> ToDriverConfig()
+        public IReadOnlyDictionary<string, string> ToDriverConfig()
         {
-            return new Dictionary<string, object>
+            return new Dictionary<string, string>
             {
                 {"bootstrap.servers", string.Join(",", BootstrapServers)},
                 {"request.required.acks", "0"} // don't wait for broker to send ACKs back (it's just trace data)

--- a/src/Petabridge.Tracing.Zipkin/ZipkinTracer.cs
+++ b/src/Petabridge.Tracing.Zipkin/ZipkinTracer.cs
@@ -7,6 +7,7 @@
 using System;
 using OpenTracing;
 using OpenTracing.Propagation;
+using OpenTracing.Util;
 using Petabridge.Tracing.Zipkin.Exceptions;
 using Petabridge.Tracing.Zipkin.Propagation;
 using Petabridge.Tracing.Zipkin.Sampling;
@@ -29,7 +30,7 @@ namespace Petabridge.Tracing.Zipkin
             _reporter = options.Reporter;
             LocalEndpoint = options.LocalEndpoint;
             TimeProvider = options.TimeProvider ?? new DateTimeOffsetTimeProvider();
-            ScopeManager = options.ScopeManager ?? NoOp.ScopeManager;
+            ScopeManager = options.ScopeManager ?? new AsyncLocalScopeManager();
             IdProvider = options.IdProvider ?? ThreadLocalRngSpanIdProvider.TraceId128BitProvider;
             Sampler = options.Sampler ?? NoSampler.Instance;
             Options = options;

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2018 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.5.2</VersionPrefix>
-    <PackageReleaseNotes>Upgraded all dependencies.</PackageReleaseNotes>
+    <VersionPrefix>0.5.3</VersionPrefix>
+    <PackageReleaseNotes>Upgraded to latest Akka.NET, Kafka drivers.
+[OpenTracing: Using AsyncLocalScopeManager as a default tracer's ScopeManager](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/131)</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://github.com/petabridge/Petabridge.Tracing.Zipkin

--- a/src/common.props
+++ b/src/common.props
@@ -15,7 +15,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
-    <AkkaVersion>1.3.16</AkkaVersion>
+    <AkkaVersion>1.3.17</AkkaVersion>
     <XunitVersion>2.4.1</XunitVersion>
     <NBenchVersion>1.2.2</NBenchVersion>
     <TestSdkVersion>16.4.0</TestSdkVersion>


### PR DESCRIPTION
#### 0.5.3 January 29 2020 ###
* Upgraded to latest Akka.NET, Kafka drivers.
* [OpenTracing: Using AsyncLocalScopeManager as a default tracer's ScopeManager](https://github.com/petabridge/Petabridge.Tracing.Zipkin/pull/131)