### PR TITLE
0.6.0-rc2 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,2 @@
-#### 0.6.0-rc1 March 02 2020 ###
-* Using Akka.NET v1.4.0-rc1 internally.
+#### 0.6.0-rc2 March 10 2020 ###
+* Using Akka.NET v1.4.0-rc3 internally.

--- a/src/Petabridge.Tracing.Zipkin/Reporting/Http/ZipkinHttpSpanReporter.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/Http/ZipkinHttpSpanReporter.cs
@@ -8,7 +8,6 @@ using System;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Util.Internal;
-using Hocon;
 
 namespace Petabridge.Tracing.Zipkin.Reporting.Http
 {

--- a/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/ZipkinKafkaSpanReporter.cs
+++ b/src/Petabridge.Tracing.Zipkin/Reporting/Kafka/ZipkinKafkaSpanReporter.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Util.Internal;
-using Hocon;
 
 namespace Petabridge.Tracing.Zipkin.Reporting.Kafka
 {

--- a/src/common.props
+++ b/src/common.props
@@ -15,7 +15,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
-    <AkkaVersion>1.4.1-rc1</AkkaVersion>
+    <AkkaVersion>1.4.1-rc3</AkkaVersion>
     <XunitVersion>2.4.1</XunitVersion>
     <NBenchVersion>2.0.1</NBenchVersion>
     <TestSdkVersion>16.5.0</TestSdkVersion>


### PR DESCRIPTION
#### 0.6.0-rc2 March 10 2020 ###
* Using Akka.NET v1.4.0-rc3 internally.